### PR TITLE
Make Cash state of Corda transferable between different Corda networks via ICS-20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,44 +27,41 @@ killNodes:
 	kill -9 $$(jps -l | grep 'main class information unavailable' | cut -d ' ' -f 1)
 
 prepareHostA:
-	./gradlew :grpc-adapter:runServer --args 'localhost 10006 user1 test 9999' &
+	./gradlew :grpc-adapter:runServer --args 'localhost 10012 user1 test 9999' &
 	sleep 20
-	$(CLIENT) genesis create-genesis -e http://localhost:9999 -p PartyA > base-hash-a.txt
+	$(CLIENT) genesis create-genesis -e http://localhost:9999 -p PartyA,Bank,Notary > base-hash-a.txt
 	$(CLIENT) admin shutdown         -e http://localhost:9999
-	./gradlew :grpc-adapter:runServer --args "localhost 10006 user1 test 9999 `cat base-hash-a.txt`" &
+	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 9999 `cat base-hash-a.txt`" &
 	sleep 20
-	$(CLIENT) host create-host   -e http://localhost:9999
-	$(CLIENT) bank create-bank   -e http://localhost:9999
-	$(CLIENT) bank allocate-fund -e http://localhost:9999 -p cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a -d USD -a 100
-	$(CLIENT) admin shutdown     -e http://localhost:9999
+	$(CLIENT) host create-host           -e http://localhost:9999
+	$(CLIENT) cash-bank create-cash-bank -e http://localhost:9999 -b `$(CLIENT) node address-from-name -e http://localhost:9999 -n Bank`
+	$(CLIENT) cash-bank allocate-cash    -e http://localhost:9999 -o `$(CLIENT) node address-from-name -e http://localhost:9999 -n PartyA` -c USD -a 100
+	$(CLIENT) admin shutdown             -e http://localhost:9999
 
 prepareHostB:
-	./gradlew :grpc-adapter:runServer --args 'localhost 10009 user1 test 19999' &
+	./gradlew :grpc-adapter:runServer --args 'localhost 10012 user1 test 19999' &
 	sleep 20
-	$(CLIENT) genesis create-genesis -e http://localhost:19999 -p PartyB > base-hash-b.txt
+	$(CLIENT) genesis create-genesis -e http://localhost:19999 -p PartyB,Bank,Notary > base-hash-b.txt
 	$(CLIENT) admin shutdown         -e http://localhost:19999
-	./gradlew :grpc-adapter:runServer --args "localhost 10009 user1 test 19999 `cat base-hash-b.txt`" &
+	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 19999 `cat base-hash-b.txt`" &
 	sleep 20
-	$(CLIENT) host create-host -e http://localhost:19999
-	$(CLIENT) bank create-bank -e http://localhost:19999
-	$(CLIENT) admin shutdown   -e http://localhost:19999
-
-allocateForRelayerTest:
-	$(CLIENT) bank allocate-fund -e http://localhost:9999 -p cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a -d USD -a 100
+	$(CLIENT) host create-host           -e http://localhost:19999
+	$(CLIENT) cash-bank create-cash-bank -e http://localhost:19999 -b `$(CLIENT) node address-from-name -e http://localhost:19999 -n Bank`
+	$(CLIENT) admin shutdown             -e http://localhost:19999
 
 runServerA:
-	./gradlew :grpc-adapter:runServer --args "localhost 10006 user1 test 9999 `cat base-hash-a.txt`"
+	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 9999 `cat base-hash-a.txt`"
 
 startServerA:
-	./gradlew :grpc-adapter:runServer --args "localhost 10006 user1 test 9999 `cat base-hash-a.txt`" &
+	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 9999 `cat base-hash-a.txt`" &
 	sleep 10
 
 startServerB:
-	./gradlew :grpc-adapter:runServer --args "localhost 10009 user1 test 19999 `cat base-hash-b.txt`" &
+	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 19999 `cat base-hash-b.txt`" &
 	sleep 10
 
 executeOldTest:
-	./gradlew :grpc-adapter:runClient --args "executeTest localhost:9999 localhost:19999 cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a"
+	./gradlew :grpc-adapter:runClient --args "executeTest localhost:9999 localhost:19999 `$(CLIENT) node address-from-name -e http://localhost:9999 -n PartyA` `$(CLIENT) node address-from-name -e http://localhost:19999 -n PartyB`"
 
 executeTest:
 	$(CLIENT) client create-clients \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 .PHONY: deployNodes upNodes downNodes
-.PHONY: prepareHostA startServerA shutdownServerA
+.PHONY: prepareHostA startServerA shutdownServerA startServerBankA shutdownServerBankA
 .PHONY: prepareHostB startServerB shutdownServerB
 .PHONY: executeTest executeOldTest
 .PHONY: test oldTest
@@ -50,18 +50,22 @@ prepareHostB:
 	$(CLIENT) admin shutdown             -e http://localhost:19999
 
 runServerA:
-	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 9999 `cat base-hash-a.txt`"
+	./gradlew :grpc-adapter:runServer --args "localhost 10006 user1 test 9999 `cat base-hash-a.txt`"
 
 startServerA:
-	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 9999 `cat base-hash-a.txt`" &
+	./gradlew :grpc-adapter:runServer --args "localhost 10006 user1 test 9999 `cat base-hash-a.txt`" &
 	sleep 10
 
 startServerB:
-	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 19999 `cat base-hash-b.txt`" &
+	./gradlew :grpc-adapter:runServer --args "localhost 10009 user1 test 19999 `cat base-hash-b.txt`" &
+	sleep 10
+
+startServerBankA:
+	./gradlew :grpc-adapter:runServer --args "localhost 10012 user1 test 29999 `cat base-hash-a.txt`" &
 	sleep 10
 
 executeOldTest:
-	./gradlew :grpc-adapter:runClient --args "executeTest localhost:9999 localhost:19999 `$(CLIENT) node address-from-name -e http://localhost:9999 -n PartyA` `$(CLIENT) node address-from-name -e http://localhost:19999 -n PartyB`"
+	./gradlew :grpc-adapter:runClient --args "executeTest localhost:9999 localhost:19999 localhost:29999 `$(CLIENT) node address-from-name -e http://localhost:9999 -n PartyA` `$(CLIENT) node address-from-name -e http://localhost:19999 -n PartyB`"
 
 executeTest:
 	$(CLIENT) client create-clients \
@@ -84,6 +88,9 @@ shutdownServerA:
 shutdownServerB:
 	$(CLIENT) admin shutdown -e http://localhost:19999
 
+shutdownServerBankA:
+	$(CLIENT) admin shutdown -e http://localhost:29999
+
 test: prepareHostA prepareHostB startServerA startServerB executeTest shutdownServerA shutdownServerB
 
-oldTest: prepareHostA prepareHostB startServerA startServerB executeOldTest shutdownServerA shutdownServerB
+oldTest: prepareHostA prepareHostB startServerA startServerB startServerBankA executeOldTest shutdownServerA shutdownServerB shutdownServerBankA

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 .PHONY: deployNodes upNodes downNodes
 .PHONY: prepareHostA startServerA shutdownServerA
 .PHONY: prepareHostB startServerB shutdownServerB
-.PHONY: executeTest
-.PHONY: test
+.PHONY: executeTest executeOldTest
+.PHONY: test oldTest
 
 CLIENT ?= ./rust/target/release/corda-ibc-client
 
@@ -34,7 +34,7 @@ prepareHostA:
 	sleep 20
 	$(CLIENT) host create-host   -e http://localhost:9999
 	$(CLIENT) bank create-bank   -e http://localhost:9999
-	$(CLIENT) bank allocate-fund -e http://localhost:9999 -p PartyA -d USD -a 100
+	$(CLIENT) bank allocate-fund -e http://localhost:9999 -p cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a -d USD -a 100
 	$(CLIENT) admin shutdown     -e http://localhost:9999
 
 prepareHostB:
@@ -62,6 +62,9 @@ startServerB:
 	./gradlew :grpc-adapter:runServer --args "localhost 10009 user1 test 19999 `cat base-hash-b.txt`" &
 	sleep 10
 
+executeOldTest:
+	./gradlew :grpc-adapter:runClient --args "executeTest localhost:9999 localhost:19999 cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a cosmos1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqnrql8a"
+
 executeTest:
 	$(CLIENT) client create-clients \
 		--client-id-a aliceclient \
@@ -84,3 +87,5 @@ shutdownServerB:
 	$(CLIENT) admin shutdown -e http://localhost:19999
 
 test: prepareHostA prepareHostB startServerA startServerB executeTest shutdownServerA shutdownServerB
+
+oldTest: prepareHostA prepareHostB startServerA startServerB executeOldTest shutdownServerA shutdownServerB

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ downNodes:
 	-sshpass -p test ssh -p 2222 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost run gracefulShutdown
 	-sshpass -p test ssh -p 2223 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost run gracefulShutdown
 	-sshpass -p test ssh -p 2224 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost run gracefulShutdown
+	-sshpass -p test ssh -p 2225 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no user1@localhost run gracefulShutdown
 
 killNodes:
 	kill -9 $$(jps -l | grep 'main class information unavailable' | cut -d ' ' -f 1)

--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,8 @@ dependencies {
     // CorDapp dependencies.
     cordapp project(":workflows")
     cordapp project(":contracts")
+    cordapp("$corda_release_group:corda-finance-contracts:$corda_release_version")
+    cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
 
     cordaCompile "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
     cordaCompile "org.apache.logging.log4j:log4j-web:${log4j_version}"
@@ -120,6 +122,9 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         }
         cordapp project(':contracts')
         cordapp project(':workflows')
+        cordapp("$corda_release_group:corda-finance-contracts:$corda_release_version")
+        cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
+        runSchemaMigration = true
     }
     node {
         name "O=Notary,L=London,C=GB"
@@ -153,7 +158,7 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
     }
     node {
-        name "O=BankA,L=Beijing,C=CN"
+        name "O=Bank,L=Beijing,C=CN"
         p2pPort 10011
         rpcSettings {
             address("localhost:10012")

--- a/build.gradle
+++ b/build.gradle
@@ -152,6 +152,16 @@ task deployNodes(type: net.corda.plugins.Cordform, dependsOn: ['jar']) {
         sshdPort 2224
         rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
     }
+    node {
+        name "O=BankA,L=Beijing,C=CN"
+        p2pPort 10011
+        rpcSettings {
+            address("localhost:10012")
+            adminAddress("localhost:10052")
+        }
+        sshdPort 2225
+        rpcUsers = [[ user: "user1", "password": "test", "permissions": ["ALL"]]]
+    }
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ buildscript {
         grpc_version = constants.getProperty('grpcVersion')
         protobuf_version = constants.getProperty('protobufVersion')
         protoc_version = constants.getProperty('protocVersion')
+        bitcoinj_version = constants.getProperty('bitcoinjVersion')
     }
 
     repositories {

--- a/constants.properties
+++ b/constants.properties
@@ -14,3 +14,5 @@ nettyVersion=4.1.22.Final
 grpcVersion=1.33.1
 protobufVersion=3.12.0
 protocVersion=3.12.0
+
+bitcoinjVersion=0.15.10

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -23,8 +23,12 @@ dependencies {
 
     compile group: 'io.grpc', name: 'grpc-netty-shaded', version: "$grpc_version"
 
+    // https://mvnrepository.com/artifact/org.bitcoinj/bitcoinj-core
+    compile group: 'org.bitcoinj', name: 'bitcoinj-core', version: "$bitcoinj_version"
+
     // Corda dependencies.
     cordaCompile "$corda_core_release_group:corda-core:$corda_core_release_version"
+    cordaCompile "$corda_release_group:corda-finance-contracts:$corda_release_version"
 
     // Classes auto-generated from IBC protocol buffer definition
     compile project(":proto")

--- a/contracts/build.gradle
+++ b/contracts/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 
     // Corda dependencies.
     cordaCompile "$corda_core_release_group:corda-core:$corda_core_release_version"
-    cordaCompile "$corda_release_group:corda-finance-contracts:$corda_release_version"
+    cordapp("$corda_release_group:corda-finance-contracts:$corda_release_version")
 
     // Classes auto-generated from IBC protocol buffer definition
     compile project(":proto")

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/clients/corda/CordaClientState.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/clients/corda/CordaClientState.kt
@@ -120,6 +120,7 @@ data class CordaClientState constructor(
         }.toSet()
         val context = SerializationFactory.defaultFactory.defaultContext
                 .withClassLoader(attachmentsClassLoader)
+                .withLenientCarpenter()
                 .withCustomSerializers(serializers)
         val outputs = SerializationFactory.defaultFactory.withCurrentContext(context) {
             proof.toSignedTransaction().tx.outputsOfType<T>()

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/clients/corda/CordaClientState.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/clients/corda/CordaClientState.kt
@@ -96,6 +96,7 @@ data class CordaClientState constructor(
                 "ConnectionEndSerializer",
                 "CordaClientStateSerializer",
                 "CordaConsensusStateSerializer",
+                "DenomTraceSerializer",
                 "FabricClientStateSerializer",
                 "FabricConsensusStateSerializer",
                 "HeightSerializer",

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/contracts/Ibc.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/contracts/Ibc.kt
@@ -72,7 +72,7 @@ class Ibc : Contract {
             override fun verify(tx: LedgerTransaction) = requireThat {
                 "Exactly one state should be consumed" using (tx.inputs.size == 1)
                 "Exactly two states should be created" using (tx.outputs.size == 2)
-                val signers = tx.commands.requireSingleCommand<BankCreate>().signers
+                val signers = tx.commands.requireSingleCommand<CashBankCreate>().signers
                 val host = tx.inRefsOfType<Host>().single()
                 val newHost = tx.outputsOfType<Host>().single()
                 val newBank = tx.outputsOfType<CashBank>().single()

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/contracts/Ibc.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/contracts/Ibc.kt
@@ -18,17 +18,18 @@ import net.corda.core.transactions.LedgerTransaction
 
 class Ibc : Contract {
     override fun verify(tx: LedgerTransaction) {
-        val commandSigners = tx.commands.single()
-        val command = commandSigners.value
-        val signers = commandSigners.signers
-        when (command) {
-            is Commands -> {
-                command.verify(tx)
-            }
-            is DatagramHandler -> {
-                val ctx = Context(tx.inputsOfType(), tx.referenceInputsOfType())
-                command.execute(ctx, signers)
-                ctx.verifyResults(tx.outputsOfType())
+        for (commandSigners in tx.commands) {
+            val command = commandSigners.value
+            val signers = commandSigners.signers
+            when (command) {
+                is Commands -> {
+                    command.verify(tx)
+                }
+                is DatagramHandler -> {
+                    val ctx = Context(tx.inputsOfType(), tx.referenceInputsOfType())
+                    command.execute(ctx, signers)
+                    ctx.verifyResults(tx.outputsOfType())
+                }
             }
         }
     }

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/conversion/conversion.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/conversion/conversion.kt
@@ -2,12 +2,14 @@ package jp.datachain.corda.ibc.conversion
 
 import com.google.protobuf.ByteString
 import ibc.lightclients.corda.v1.BankProto
+import ibc.lightclients.corda.v1.CashBankProto
 import ibc.lightclients.corda.v1.CordaTypes
 import ibc.lightclients.corda.v1.HostProto
 import jp.datachain.corda.ibc.ics20.Address
 import jp.datachain.corda.ibc.ics20.Amount
 import jp.datachain.corda.ibc.ics20.Bank
 import jp.datachain.corda.ibc.ics20.Denom
+import jp.datachain.corda.ibc.ics20cash.CashBank
 import jp.datachain.corda.ibc.ics24.Host
 import jp.datachain.corda.ibc.ics24.Identifier
 import net.corda.core.contracts.StateRef
@@ -125,3 +127,30 @@ fun BankProto.Bank.into() = Bank(
         locked = locked.into(),
         minted = minted.into(),
         denoms = denoms.into())
+
+fun Map<Denom, Amount>.into() = CashBankProto.CashBank.SupplyMap.newBuilder()
+        .putAllDenomToAmount(this
+                .mapKeys{it.key.toString()}
+                .mapValues{it.value.toString()})
+        .build()
+fun CashBankProto.CashBank.SupplyMap.into(): Map<Denom, Amount> = denomToAmountMap
+        .mapKeys{Denom.fromString(it.key)}
+        .mapValues{Amount.fromString(it.value)}
+
+fun Map<String, Denom>.into(): CashBankProto.CashBank.IbcDenomMap = CashBankProto.CashBank.IbcDenomMap.newBuilder()
+        .putAllIbcDenomToDenom(this
+                .mapKeys{it.key}
+                .mapValues{it.value.toString()})
+        .build()
+fun CashBankProto.CashBank.IbcDenomMap.into(): Map<String, Denom> = ibcDenomToDenomMap
+        .mapValues{Denom.fromString(it.value)}
+        .toMap()
+
+fun CashBank.into() = CashBankProto.CashBank.newBuilder()
+        .addAllParticipants(participants.map{Party(it.nameOrNull()!!, it.owningKey).into()})
+        .setBaseId(baseId.into())
+        .setOwner(owner.into())
+        .setSupply(supply.into())
+        .setDenoms(denoms.into())
+        .setId(id.id)
+        .build()

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/conversion/conversion.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/conversion/conversion.kt
@@ -81,27 +81,32 @@ fun HostProto.Host.into() = Host(
 )
 
 fun MutableMap<Address, Amount>.into(): BankProto.Bank.BalanceMapPerDenom = BankProto.Bank.BalanceMapPerDenom.newBuilder()
-        .putAllPubkeyToAmount(this.mapKeys{it.key.address}.mapValues{it.value.amount.toString()})
+        .putAllPubkeyToAmount(this
+                .mapKeys{it.key.toBech32()}
+                .mapValues{it.value.toString()})
         .build()
 fun BankProto.Bank.BalanceMapPerDenom.into() = pubkeyToAmountMap
-        .mapKeys{Address(it.key)}
-        .mapValues{Amount(it.value.toBigInteger())}
+        .mapKeys{Address.fromBech32(it.key)}
+        .mapValues{Amount.fromString(it.value)}
         .toMutableMap()
 
 fun MutableMap<Denom, MutableMap<Address, Amount>>.into(): BankProto.Bank.BalanceMap = BankProto.Bank.BalanceMap.newBuilder()
-        .putAllDenomToMap(this.mapKeys{it.key.denom}.mapValues{it.value.into()})
+        .putAllDenomToMap(this
+                .mapKeys{it.key.toString()}
+                .mapValues{it.value.into()})
         .build()
 fun BankProto.Bank.BalanceMap.into() = denomToMapMap
-        .mapKeys{Denom(it.key)}
+        .mapKeys{Denom.fromString(it.key)}
         .mapValues{it.value.into()}
         .toMutableMap()
 
-fun MutableMap<Denom, Denom>.into(): BankProto.Bank.IbcDenomMap = BankProto.Bank.IbcDenomMap.newBuilder()
-        .putAllIbcDenomToDenom(this.mapKeys{it.key.denom}.mapValues{it.value.denom})
+fun MutableMap<String, Denom>.into(): BankProto.Bank.IbcDenomMap = BankProto.Bank.IbcDenomMap.newBuilder()
+        .putAllIbcDenomToDenom(this
+                .mapKeys{it.key}
+                .mapValues{it.value.toString()})
         .build()
 fun BankProto.Bank.IbcDenomMap.into() = ibcDenomToDenomMap
-        .mapKeys{Denom(it.key)}
-        .mapValues{Denom(it.value)}
+        .mapValues{Denom.fromString(it.value)}
         .toMutableMap()
 
 fun Bank.into(): BankProto.Bank = BankProto.Bank.newBuilder()

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Address.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Address.kt
@@ -1,12 +1,12 @@
 package jp.datachain.corda.ibc.ics20
 
 import net.corda.core.crypto.Crypto
-import net.corda.core.identity.AnonymousParty
 import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.parseAsHex
 import net.corda.core.utilities.toHexString
 import org.bitcoinj.core.Bech32
+import java.security.PublicKey
 
 @CordaSerializable
 class Address(bytes: ByteArray): OpaqueBytes(bytes) {
@@ -22,10 +22,10 @@ class Address(bytes: ByteArray): OpaqueBytes(bytes) {
 
         fun fromHex(hex: String) = Address(hex.parseAsHex())
         fun fromBech32(bech32: String) = Address(decodeBech32(bech32))
-        fun fromAnonParty(party: AnonymousParty) = Address(party.owningKey.encoded)
+        fun fromPublicKey(pubkey: PublicKey) = Address(pubkey.encoded)
     }
 
     fun toHex() : String = bytes.toHexString()
     fun toBech32() : String = encodeBech32(bytes)
-    fun toAnonParty() = AnonymousParty(Crypto.decodePublicKey(bytes))
+    fun toPublicKey() = Crypto.decodePublicKey(bytes)
 }

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Address.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Address.kt
@@ -1,6 +1,31 @@
 package jp.datachain.corda.ibc.ics20
 
+import net.corda.core.crypto.Crypto
+import net.corda.core.identity.AnonymousParty
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.parseAsHex
+import net.corda.core.utilities.toHexString
+import org.bitcoinj.core.Bech32
 
 @CordaSerializable
-data class Address(val address: String)
+class Address(bytes: ByteArray): OpaqueBytes(bytes) {
+    companion object {
+        private const val PREFIX = "cosmos"
+
+        private fun decodeBech32(bech32: String) = Bech32.decode(bech32).let{
+            require(it.hrp == PREFIX)
+            it.data
+        }
+
+        private fun encodeBech32(value: ByteArray) = Bech32.encode(PREFIX, value)
+
+        fun fromHex(hex: String) = Address(hex.parseAsHex())
+        fun fromBech32(bech32: String) = Address(decodeBech32(bech32))
+        fun fromAnonParty(party: AnonymousParty) = Address(party.owningKey.encoded)
+    }
+
+    fun toHex() : String = bytes.toHexString()
+    fun toBech32() : String = encodeBech32(bytes)
+    fun toAnonParty() = AnonymousParty(Crypto.decodePublicKey(bytes))
+}

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Address.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Address.kt
@@ -5,7 +5,10 @@ import net.corda.core.serialization.CordaSerializable
 import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.parseAsHex
 import net.corda.core.utilities.toHexString
+import org.bitcoinj.core.AddressFormatException
 import org.bitcoinj.core.Bech32
+import java.io.ByteArrayOutputStream
+import java.lang.IllegalArgumentException
 import java.security.PublicKey
 
 @CordaSerializable
@@ -13,12 +16,41 @@ class Address(bytes: ByteArray): OpaqueBytes(bytes) {
     companion object {
         private const val PREFIX = "cosmos"
 
-        private fun decodeBech32(bech32: String) = Bech32.decode(bech32).let{
-            require(it.hrp == PREFIX)
-            it.data
+        private fun ByteArray.convertBits(fromBits: Int, toBits: Int, pad: Boolean): ByteArray {
+            assert(fromBits <= 8)
+            assert(toBits <= 8)
+
+            var acc = 0
+            var bits = 0
+            val out = ByteArrayOutputStream()
+            val maxv = (1 shl toBits) - 1
+            val maxAcc = (1 shl (fromBits + toBits - 1)) - 1
+            for (i in 0 until this.size) {
+                val value: Int = this[i].toInt() and 0xff
+                if (value ushr fromBits != 0) {
+                    throw IllegalArgumentException("Input value '$value' exceeds '$fromBits' bit size")
+                }
+                acc = ((acc shl fromBits) or value) and maxAcc
+                bits += fromBits
+                while (bits >= toBits) {
+                    bits -= toBits
+                    out.write((acc ushr bits) and maxv)
+                }
+            }
+            if (pad) {
+                if (bits > 0) out.write((acc shl (toBits - bits)) and maxv)
+            } else if (bits >= fromBits || ((acc shl (toBits - bits)) and maxv) != 0) {
+                throw IllegalArgumentException("Could not convert bits, invalid padding")
+            }
+            return out.toByteArray()
         }
 
-        private fun encodeBech32(value: ByteArray) = Bech32.encode(PREFIX, value)
+        private fun decodeBech32(bech32: String) = Bech32.decode(bech32).let{
+            require(it.hrp == PREFIX)
+            it.data.convertBits(5, 8, false)
+        }
+
+        private fun encodeBech32(value: ByteArray) = Bech32.encode(PREFIX, value.convertBits(8, 5, true))
 
         fun fromHex(hex: String) = Address(hex.parseAsHex())
         fun fromBech32(bech32: String) = Address(decodeBech32(bech32))

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Amount.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Amount.kt
@@ -4,9 +4,16 @@ import net.corda.core.serialization.CordaSerializable
 import java.math.BigInteger
 
 @CordaSerializable
-data class Amount(val amount: BigInteger) {
-    constructor(amount: Long): this(BigInteger.valueOf(amount))
-    constructor(amount: String): this(amount.toBigInteger())
+data class Amount(private val amount: BigInteger) {
+    companion object {
+        val ZERO = Amount(BigInteger.ZERO)
+
+        fun fromLong(amount: Long) = Amount(BigInteger.valueOf(amount))
+        fun fromString(amount: String) = Amount(amount.toBigInteger())
+    }
+
+    fun toLong() = amount.longValueExact()
+    override fun toString() = amount.toString()
 
     operator fun plus(amount: Amount) = Amount(this.amount + amount.amount)
     operator fun minus(amount: Amount) = Amount(this.amount - amount.amount)

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Bank.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Bank.kt
@@ -16,7 +16,7 @@ data class Bank(
         val allocated: MutableMap<Denom, MutableMap<Address, Amount>>,
         val locked: MutableMap<Denom, MutableMap<Address, Amount>>,
         val minted: MutableMap<Denom, MutableMap<Address, Amount>>,
-        val denoms: MutableMap<Denom, Denom>
+        val denoms: MutableMap<String, Denom>
 ): IbcState {
     override val id = Identifier("bank")
 
@@ -77,8 +77,8 @@ data class Bank(
     }
 
     fun recordDenom(denom: Denom) = deepCopy().apply{
-        denoms[denom.ibcDenom] = denom
+        denoms[denom.toIbcDenom()] = denom
     }
 
-    fun resolveDenom(ibcDenom: Denom) = denoms[ibcDenom] ?: throw IllegalArgumentException()
+    fun resolveDenom(ibcDenom: String) = denoms[ibcDenom] ?: throw java.lang.IllegalArgumentException("unknown IBC denom: $ibcDenom")
 }

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Denom.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Denom.kt
@@ -1,33 +1,92 @@
 package jp.datachain.corda.ibc.ics20
 
+import ibc.applications.transfer.v1.Transfer
 import jp.datachain.corda.ibc.ics24.Identifier
+import net.corda.core.contracts.Issued
+import net.corda.core.contracts.PartyAndReference
+import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
+import net.corda.core.identity.CordaX500Name
+import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.hexToByteArray
 import net.corda.core.utilities.toHex
+import java.util.*
+import javax.security.auth.x500.X500Principal
 
 @CordaSerializable
-data class Denom(val denom: String) {
-    fun hasPrefix(portId: Identifier, chanId: Identifier): Boolean {
-        denom.split('/').let {
-            return it.size == 3 && it[0] == portId.id && it[1] == chanId.id
+data class Denom(val denomTrace: Transfer.DenomTrace) {
+
+    companion object {
+        private fun encodeToken(token: Issued<Currency>) : String {
+            val party = token.issuer.party as Party
+            val partyName = party.name.x500Principal.encoded.toHex()
+            val partyKey = party.owningKey.encoded.toHex()
+            val reference = token.issuer.reference.bytes.toHex()
+            val currency = token.product.currencyCode
+            return "$partyName:$partyKey:$reference:$currency"
         }
-    }
 
-    fun addPrefix(portId: Identifier, chanId: Identifier) = Denom("${portId.id}/${chanId.id}/$denom")
+        private fun decodeToken(denom: String) : Issued<Currency> {
+            val words = denom.split(':')
+            require(words.size == 4)
 
-    fun removePrefix(): Denom = denom.split('/').let {
-        assert(it.size == 3)
-        Denom(it[2])
-    }
+            // decode party
+            val partyName = CordaX500Name.build(X500Principal(words[0].hexToByteArray()))
+            val partyKey = Crypto.decodePublicKey(words[1].hexToByteArray())
+            val party = Party(partyName, partyKey)
 
-    fun hasIbcPrefix(): Boolean = denom.split('/').let {
-        assert(it.size == 2)
-        it[0] == "ibc"
-    }
+            // decode reference
+            val reference = OpaqueBytes(words[2].hexToByteArray())
 
-    val ibcDenom: Denom
-        get() {
-            val hash = SecureHash.sha256(denom).bytes.toHex()
-            return Denom("ibc/$hash")
+            // issuer = party + reference
+            val issuer = PartyAndReference(party, reference)
+
+            // decode currency
+            val currency = Currency.getInstance(words[3])!!
+
+            return Issued(issuer, currency)
         }
+
+        fun fromToken(token: Issued<Currency>) = Denom(
+                Transfer.DenomTrace.newBuilder()
+                        .setBaseDenom(encodeToken(token))
+                        .build())
+
+        fun fromString(denom: String) = Denom(
+                denom.split('/').let {
+                    Transfer.DenomTrace.newBuilder()
+                            .setPath(it.dropLast(1).joinToString("/"))
+                            .setBaseDenom(it.last())
+                            .build()
+                })
+    }
+
+    fun addPath(portId: Identifier, chanId: Identifier) = Denom(denomTrace.toBuilder()
+            .setPath(denomTrace.path.addPath(portId, chanId))
+            .build())
+
+    fun hasPrefix(portId: Identifier, chanId: Identifier)
+            = denomTrace.path.hasPrefixes(portId.id, chanId.id)
+
+    fun removePrefix() = Denom(denomTrace.toBuilder()
+            .setPath(denomTrace.path.removePrefix())
+            .build())
+
+    override fun toString() = if (denomTrace.path.isEmpty()) {
+        denomTrace.baseDenom
+    } else {
+        "${denomTrace.path}/${denomTrace.baseDenom}"
+    }
+
+    fun toToken() : Issued<Currency> {
+        require(denomTrace.path.isEmpty())
+        return decodeToken(this.denomTrace.baseDenom)
+    }
+
+    fun toIbcDenom() : String {
+        val hash = SecureHash.sha256(toString()).bytes.toHex()
+        return "ibc/$hash"
+    }
 }

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Denom.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/Denom.kt
@@ -2,57 +2,33 @@ package jp.datachain.corda.ibc.ics20
 
 import ibc.applications.transfer.v1.Transfer
 import jp.datachain.corda.ibc.ics24.Identifier
-import net.corda.core.contracts.Issued
-import net.corda.core.contracts.PartyAndReference
 import net.corda.core.crypto.Crypto
 import net.corda.core.crypto.SecureHash
-import net.corda.core.identity.CordaX500Name
-import net.corda.core.identity.Party
 import net.corda.core.serialization.CordaSerializable
-import net.corda.core.utilities.OpaqueBytes
 import net.corda.core.utilities.hexToByteArray
 import net.corda.core.utilities.toHex
+import java.security.PublicKey
 import java.util.*
-import javax.security.auth.x500.X500Principal
 
 @CordaSerializable
 data class Denom(val denomTrace: Transfer.DenomTrace) {
 
     companion object {
-        private fun encodeToken(token: Issued<Currency>) : String {
-            val party = token.issuer.party as Party
-            val partyName = party.name.x500Principal.encoded.toHex()
-            val partyKey = party.owningKey.encoded.toHex()
-            val reference = token.issuer.reference.bytes.toHex()
-            val currency = token.product.currencyCode
-            return "$partyName:$partyKey:$reference:$currency"
+        private fun encodeIssuedCurrency(issuerKey: PublicKey, currency: Currency) : String {
+            val issuerKeyString = issuerKey.encoded.toHex()
+            val currencyString = currency.currencyCode
+            return "$issuerKeyString:$currencyString"
         }
 
-        private fun decodeToken(denom: String) : Issued<Currency> {
-            val words = denom.split(':')
-            require(words.size == 4)
-
-            // decode party
-            val partyName = CordaX500Name.build(X500Principal(words[0].hexToByteArray()))
-            val partyKey = Crypto.decodePublicKey(words[1].hexToByteArray())
-            val party = Party(partyName, partyKey)
-
-            // decode reference
-            val reference = OpaqueBytes(words[2].hexToByteArray())
-
-            // issuer = party + reference
-            val issuer = PartyAndReference(party, reference)
-
-            // decode currency
-            val currency = Currency.getInstance(words[3])!!
-
-            return Issued(issuer, currency)
+        private fun decodeIssuedCurrency(issuedCurrency: String) : Pair<PublicKey, Currency> {
+            val words = issuedCurrency.split(':')
+            require(words.size == 2)
+            val issuerKey = Crypto.decodePublicKey(words[0].hexToByteArray())
+            val currency = Currency.getInstance(words[1])!!
+            return Pair(issuerKey, currency)
         }
 
-        fun fromToken(token: Issued<Currency>) = Denom(
-                Transfer.DenomTrace.newBuilder()
-                        .setBaseDenom(encodeToken(token))
-                        .build())
+        fun fromIssuedCurrency(issuerKey: PublicKey, currency: Currency) = fromString(encodeIssuedCurrency(issuerKey, currency))
 
         fun fromString(denom: String) = Denom(
                 denom.split('/').let {
@@ -74,15 +50,24 @@ data class Denom(val denomTrace: Transfer.DenomTrace) {
             .setPath(denomTrace.path.removePrefix())
             .build())
 
-    override fun toString() = if (denomTrace.path.isEmpty()) {
-        denomTrace.baseDenom
-    } else {
-        "${denomTrace.path}/${denomTrace.baseDenom}"
+    fun isVoucher() = denomTrace.path.isNotEmpty()
+
+    val issuerKey: PublicKey get() {
+        require(!isVoucher())
+        val (issuerKey, _) = decodeIssuedCurrency(denomTrace.baseDenom)
+        return issuerKey
     }
 
-    fun toToken() : Issued<Currency> {
-        require(denomTrace.path.isEmpty())
-        return decodeToken(this.denomTrace.baseDenom)
+    val currency: Currency get() {
+        require(!isVoucher())
+        val (_, currency) = decodeIssuedCurrency(denomTrace.baseDenom)
+        return currency
+    }
+
+    override fun toString() = if (isVoucher()) {
+        "${denomTrace.path}/${denomTrace.baseDenom}"
+    } else {
+        denomTrace.baseDenom!!
     }
 
     fun toIbcDenom() : String {

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/denom-path.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/denom-path.kt
@@ -13,8 +13,12 @@ fun String.addPath(portId: Identifier, channelId: Identifier): String {
 
 fun String.removePrefix(): String {
     val components = split('/', ignoreCase = false, limit = 3)
-    require(components.size == 3)
-    return components.last()
+    return if (components.size == 2) {
+        ""
+    } else {
+        require(components.size == 3)
+        components.last()
+    }
 }
 
 fun String.hasPrefixes(vararg prefixes: String): Boolean {

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/denom-path.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20/denom-path.kt
@@ -1,0 +1,31 @@
+package jp.datachain.corda.ibc.ics20
+
+import jp.datachain.corda.ibc.ics24.Identifier
+
+fun String.addPath(portId: Identifier, channelId: Identifier): String {
+    val newPath = "${portId.id}/${channelId.id}"
+    return if (this.isEmpty()) {
+        newPath
+    } else {
+        "$newPath/$this"
+    }
+}
+
+fun String.removePrefix(): String {
+    val components = split('/', ignoreCase = false, limit = 3)
+    require(components.size == 3)
+    return components.last()
+}
+
+fun String.hasPrefixes(vararg prefixes: String): Boolean {
+    val components = split('/')
+    if (components.size < prefixes.size) {
+        return false
+    }
+    prefixes.forEachIndexed { i, prefix ->
+        if (components[i] != prefix) {
+            return false
+        }
+    }
+    return true
+}

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/Bank.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/Bank.kt
@@ -1,0 +1,51 @@
+package jp.datachain.corda.ibc.ics20cash
+
+import jp.datachain.corda.ibc.contracts.Ibc
+import jp.datachain.corda.ibc.ics20.Address
+import jp.datachain.corda.ibc.ics20.Amount
+import jp.datachain.corda.ibc.ics20.Denom
+import jp.datachain.corda.ibc.ics24.Host
+import jp.datachain.corda.ibc.ics24.Identifier
+import jp.datachain.corda.ibc.states.IbcState
+import net.corda.core.contracts.BelongsToContract
+import net.corda.core.contracts.Issued
+import net.corda.core.contracts.StateRef
+import net.corda.core.identity.AbstractParty
+
+@BelongsToContract(Ibc::class)
+data class Bank(
+        override val participants: List<AbstractParty>,
+        override val baseId: StateRef,
+        val owner: AbstractParty,
+        val supply: Map<Denom, Amount>,
+        val denoms: Map<String, Denom>
+): IbcState {
+    override val id = Identifier("bank")
+
+    constructor(host: Host, owner: AbstractParty) : this(
+            host.participants,
+            host.baseId,
+            owner,
+            emptyMap(),
+            emptyMap())
+
+    private fun setSupply(denom: Denom, amount: Amount): Bank = copy(supply = supply + Pair(denom, amount))
+
+    fun mint(owner: Address, denom: Denom, amount: Amount): Pair<Bank, Voucher> {
+        val bank = setSupply(denom, supply.getOrDefault(denom, Amount.ZERO) + amount)
+
+        val owner = owner.toAnonParty()
+        val amount = net.corda.core.contracts.Amount(amount.toLong(), Issued(owner.ref(), denom.denomTrace))
+        val voucher = Voucher(participants, owner, amount)
+
+        return Pair(bank, voucher)
+    }
+
+    fun burn(denom: Denom, amount: Amount): Bank {
+        return setSupply(denom, (supply[denom]!! - amount).also{require(it > Amount.ZERO)})
+    }
+
+    fun recordDenom(denom: Denom): Bank = copy(denoms = denoms + Pair(denom.toIbcDenom(), denom))
+
+    fun resolveDenom(ibcDenom: String) = denoms[ibcDenom] ?: throw IllegalArgumentException("unknown IBC denom: $ibcDenom")
+}

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/CashBank.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/CashBank.kt
@@ -11,41 +11,43 @@ import net.corda.core.contracts.BelongsToContract
 import net.corda.core.contracts.Issued
 import net.corda.core.contracts.StateRef
 import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.AnonymousParty
+import net.corda.core.identity.Party
 
 @BelongsToContract(Ibc::class)
-data class Bank(
+data class CashBank(
         override val participants: List<AbstractParty>,
         override val baseId: StateRef,
-        val owner: AbstractParty,
+        val owner: Party,
         val supply: Map<Denom, Amount>,
         val denoms: Map<String, Denom>
 ): IbcState {
     override val id = Identifier("bank")
 
-    constructor(host: Host, owner: AbstractParty) : this(
+    constructor(host: Host, owner: Party) : this(
             host.participants,
             host.baseId,
             owner,
             emptyMap(),
             emptyMap())
 
-    private fun setSupply(denom: Denom, amount: Amount): Bank = copy(supply = supply + Pair(denom, amount))
+    private fun setSupply(denom: Denom, amount: Amount): CashBank = copy(supply = supply + Pair(denom, amount))
 
-    fun mint(owner: Address, denom: Denom, amount: Amount): Pair<Bank, Voucher> {
+    fun mint(owner: Address, denom: Denom, amount: Amount): Pair<CashBank, Voucher> {
         val bank = setSupply(denom, supply.getOrDefault(denom, Amount.ZERO) + amount)
 
-        val owner = owner.toAnonParty()
+        val owner = AnonymousParty(owner.toPublicKey())
         val amount = net.corda.core.contracts.Amount(amount.toLong(), Issued(owner.ref(), denom.denomTrace))
         val voucher = Voucher(participants, owner, amount)
 
         return Pair(bank, voucher)
     }
 
-    fun burn(denom: Denom, amount: Amount): Bank {
+    fun burn(denom: Denom, amount: Amount): CashBank {
         return setSupply(denom, (supply[denom]!! - amount).also{require(it > Amount.ZERO)})
     }
 
-    fun recordDenom(denom: Denom): Bank = copy(denoms = denoms + Pair(denom.toIbcDenom(), denom))
+    fun recordDenom(denom: Denom): CashBank = copy(denoms = denoms + Pair(denom.toIbcDenom(), denom))
 
     fun resolveDenom(ibcDenom: String) = denoms[ibcDenom] ?: throw IllegalArgumentException("unknown IBC denom: $ibcDenom")
 }

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/CashBank.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/CashBank.kt
@@ -8,7 +8,6 @@ import jp.datachain.corda.ibc.ics24.Host
 import jp.datachain.corda.ibc.ics24.Identifier
 import jp.datachain.corda.ibc.states.IbcState
 import net.corda.core.contracts.BelongsToContract
-import net.corda.core.contracts.Issued
 import net.corda.core.contracts.StateRef
 import net.corda.core.identity.AbstractParty
 import net.corda.core.identity.AnonymousParty
@@ -37,14 +36,14 @@ data class CashBank(
         val bank = setSupply(denom, supply.getOrDefault(denom, Amount.ZERO) + amount)
 
         val owner = AnonymousParty(owner.toPublicKey())
-        val amount = net.corda.core.contracts.Amount(amount.toLong(), Issued(owner.ref(), denom.denomTrace))
-        val voucher = Voucher(participants, owner, amount)
+        val amount = net.corda.core.contracts.Amount(amount.toLong(), denom.denomTrace)
+        val voucher = Voucher(baseId, amount, owner)
 
         return Pair(bank, voucher)
     }
 
     fun burn(denom: Denom, amount: Amount): CashBank {
-        return setSupply(denom, (supply[denom]!! - amount).also{require(it > Amount.ZERO)})
+        return setSupply(denom, (supply[denom]!! - amount).also{require(it >= Amount.ZERO)})
     }
 
     fun recordDenom(denom: Denom): CashBank = copy(denoms = denoms + Pair(denom.toIbcDenom(), denom))

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/HandleTransfer.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/HandleTransfer.kt
@@ -1,0 +1,81 @@
+package jp.datachain.corda.ibc.ics20cash
+
+import ibc.applications.transfer.v1.Transfer
+import ibc.applications.transfer.v1.Tx
+import ibc.core.channel.v1.ChannelOuterClass
+import jp.datachain.corda.ibc.ics20.*
+import jp.datachain.corda.ibc.ics24.Identifier
+import jp.datachain.corda.ibc.ics25.Handler
+import jp.datachain.corda.ibc.ics26.DatagramHandler
+import jp.datachain.corda.ibc.ics26.Context
+import jp.datachain.corda.ibc.states.IbcChannel
+import net.corda.core.contracts.Amount.Companion.sumOrThrow
+import net.corda.finance.contracts.asset.Cash
+import java.security.PublicKey
+
+data class HandleTransfer(val msg: Tx.MsgTransfer): DatagramHandler {
+    override fun execute(ctx: Context, signers: Collection<PublicKey>) {
+        val amount = Amount.fromString(msg.token.amount)
+        val sender = Address.fromBech32(msg.sender)
+        val sourcePort = Identifier(msg.sourcePort)
+        val sourceChannel = Identifier(msg.sourceChannel)
+
+        // resolve real denom
+        val bank = ctx.getReference<Bank>()
+        val denom =
+                if (msg.token.denom.hasPrefixes("ibc"))
+                    bank.resolveDenom(msg.token.denom)
+                else
+                    Denom.fromString(msg.token.denom)
+
+        val source = !denom.hasPrefix(sourcePort, sourceChannel)
+        if (source) {
+            // verify cash owner
+            val cashes = ctx.getInputs<Cash.State>()
+            val cashOwner = cashes.map{it.owner}.distinct().single()
+            require(cashOwner.owningKey == sender.toAnonParty().owningKey)
+
+            // verify denom & amount
+            val cashSum = cashes.map{it.amount}.sumOrThrow() // sumOrThrow ensures all Cashes have same token (= issuer + currency)
+            require(cashSum.token == denom.toToken())
+            require(cashSum.quantity == amount.toLong())
+
+            // lock assets = transfer Cash from sender to Bank user
+            ctx.addOutput(Cash.State(cashSum, bank.owner))
+        } else {
+            // verify voucher owner
+            val vouchers = ctx.getInputs<Voucher>()
+            val voucherOwner = vouchers.map{it.owner}.distinct().single()
+            require(voucherOwner.owningKey == sender.toAnonParty().owningKey)
+
+            // verify denom & amount
+            val voucherSum = vouchers.map{it.amount}.sumOrThrow() // sumCash ensures all Vouchers have same token (= issuer + currency)
+            require(voucherSum.token.issuer.party == bank.owner)
+            require(voucherSum.token.product == denom.denomTrace)
+            require(voucherSum.quantity == amount.toLong())
+
+            // burn vouchers
+            ctx.addOutput(ctx.getInput<Bank>().burn(denom, amount))
+        }
+
+        val data = Transfer.FungibleTokenPacketData.newBuilder()
+                .setDenom(denom.toString())
+                .setAmount(msg.token.amount.toLong())
+                .setSender(msg.sender)
+                .setReceiver(msg.receiver)
+                .build()
+
+        val channel = ctx.getInput<IbcChannel>()
+        val packet = ChannelOuterClass.Packet.newBuilder()
+                .setSequence(channel.nextSequenceSend)
+                .setSourcePort(msg.sourcePort)
+                .setSourceChannel(msg.sourceChannel)
+                .setDestinationPort(channel.end.counterparty.portId)
+                .setDestinationChannel(channel.end.counterparty.channelId)
+                .setData(data.toJson())
+                .setTimeoutHeight(msg.timeoutHeight)
+                .setTimeoutTimestamp(msg.timeoutTimestamp)
+                .build()
+        Handler.sendPacket(ctx, packet)
+    }
+}

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/ModuleCallbacks.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/ModuleCallbacks.kt
@@ -1,0 +1,104 @@
+package jp.datachain.corda.ibc.ics20cash
+
+import com.google.protobuf.ByteString
+import ibc.core.channel.v1.ChannelOuterClass
+import jp.datachain.corda.ibc.ics20.Address
+import jp.datachain.corda.ibc.ics20.Amount
+import jp.datachain.corda.ibc.ics20.Denom
+import jp.datachain.corda.ibc.ics20.toFungibleTokenPacketData
+import jp.datachain.corda.ibc.ics24.Identifier
+import jp.datachain.corda.ibc.ics26.Context
+import jp.datachain.corda.ibc.ics26.ModuleCallbacks
+import net.corda.core.contracts.Amount.Companion.sumOrThrow
+import net.corda.finance.contracts.asset.Cash
+
+class ModuleCallbacks: ModuleCallbacks {
+    override fun onRecvPacket(ctx: Context, packet: ChannelOuterClass.Packet): ChannelOuterClass.Acknowledgement {
+        val data = packet.data.toFungibleTokenPacketData()
+        val denom = Denom.fromString(data.denom)
+        val amount = Amount.fromLong(data.amount)
+        val receiver = Address.fromBech32(data.receiver)
+
+        val ackBuilder = ChannelOuterClass.Acknowledgement.newBuilder()
+        val source = denom.hasPrefix(Identifier(packet.sourcePort), Identifier(packet.sourceChannel))
+        val bank = ctx.getInput<Bank>()
+
+        if (source) {
+            try {
+                // verify cash owner
+                val cashes = ctx.getInputs<Cash.State>()
+                val cashOwner = cashes.map{it.owner}.distinct().single()
+                require(cashOwner == bank.owner)
+
+                // verify denom & amount
+                val cashSum = cashes.map{it.amount}.sumOrThrow() // sumOrThrow ensures all Cashes have same token (= issuer + currency)
+                val unprefixedDenom = denom.removePrefix()
+                require(cashSum.token == unprefixedDenom.toToken())
+                require(cashSum.quantity == amount.toLong())
+
+                // unlock assets = transfer Cash from Bank user to receiver
+                ctx.addOutput(Cash.State(cashSum, receiver.toAnonParty()))
+
+                ackBuilder.result = ByteString.copyFrom(ByteArray(1){1})
+            } catch (e: IllegalArgumentException) {
+                ctx.addOutput(bank.copy())
+                ackBuilder.error = e.message!!
+            }
+        } else {
+            try {
+                // prefix locak port/channel identifiers to denom
+                val denom = denom.addPath(Identifier(packet.destinationPort), Identifier(packet.destinationChannel))
+
+                // mint voucher
+                val (bank, voucher) = bank.recordDenom(denom).mint(receiver, denom, amount)
+                ctx.addOutput(bank)
+                ctx.addOutput(voucher)
+
+                ackBuilder.result = ByteString.copyFrom(ByteArray(1){1})
+            } catch (e: IllegalArgumentException) {
+                ctx.addOutput(bank.copy())
+                ackBuilder.error = e.message!!
+            }
+        }
+        return ackBuilder.build()
+    }
+
+    override fun onAcknowledgePacket(ctx: Context, packet: ChannelOuterClass.Packet, acknowledgement: ChannelOuterClass.Acknowledgement) {
+        when (acknowledgement.responseCase) {
+            ChannelOuterClass.Acknowledgement.ResponseCase.RESULT ->
+                ctx.addOutput(ctx.getInput<Bank>().copy())
+            ChannelOuterClass.Acknowledgement.ResponseCase.ERROR ->
+                refundTokens(ctx, packet)
+            else -> throw java.lang.IllegalArgumentException()
+        }
+    }
+
+    private fun refundTokens(ctx: Context, packet: ChannelOuterClass.Packet) {
+        val data = packet.data.toFungibleTokenPacketData()
+        val denom = Denom.fromString(data.denom)
+        val amount = Amount.fromLong(data.amount)
+        val sender = Address.fromBech32(data.sender)
+
+        val source = !denom.hasPrefix(Identifier(packet.sourcePort), Identifier(packet.sourceChannel))
+        val bank = ctx.getInput<Bank>()
+        if (source) {
+            // verify cash owner
+            val cashes = ctx.getInputs<Cash.State>()
+            val cashOwner = cashes.map{it.owner}.distinct().single()
+            require(cashOwner == bank.owner)
+
+            // verify denom & amount
+            val cashSum = cashes.map{it.amount}.sumOrThrow() // sumOrThrow ensures all Cashes have same token (= issuer + currency)
+            require(cashSum.token == denom.toToken())
+            require(cashSum.quantity == amount.toLong())
+
+            // unlock assets = refund Cash from Bank user to receiver
+            ctx.addOutput(Cash.State(cashSum, sender.toAnonParty()))
+        } else {
+            // re-mint voucher
+            val (bank, voucher) = bank.mint(sender, denom, amount)
+            ctx.addOutput(bank)
+            ctx.addOutput(voucher)
+        }
+    }
+}

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/Voucher.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/Voucher.kt
@@ -4,6 +4,7 @@ import ibc.applications.transfer.v1.Transfer
 import jp.datachain.corda.ibc.contracts.Ibc
 import net.corda.core.contracts.*
 import net.corda.core.identity.AbstractParty
+import net.corda.core.identity.AnonymousParty
 import net.corda.core.serialization.CordaSerializable
 import java.security.PublicKey
 
@@ -11,7 +12,7 @@ import java.security.PublicKey
 @CordaSerializable
 data class Voucher(
         override val participants: List<AbstractParty>,
-        override val owner: AbstractParty,
+        override val owner: AnonymousParty,
         override val amount: Amount<Issued<Transfer.DenomTrace>>
 ): FungibleAsset<Transfer.DenomTrace> {
     override val exitKeys: Collection<PublicKey> get() = setOf(owner.owningKey, amount.token.issuer.party.owningKey)

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/Voucher.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/Voucher.kt
@@ -2,25 +2,21 @@ package jp.datachain.corda.ibc.ics20cash
 
 import ibc.applications.transfer.v1.Transfer
 import jp.datachain.corda.ibc.contracts.Ibc
+import jp.datachain.corda.ibc.states.IbcFungibleState
 import net.corda.core.contracts.*
 import net.corda.core.identity.AbstractParty
-import net.corda.core.identity.AnonymousParty
 import net.corda.core.serialization.CordaSerializable
-import java.security.PublicKey
 
 @BelongsToContract(Ibc::class)
 @CordaSerializable
 data class Voucher(
-        override val participants: List<AbstractParty>,
-        override val owner: AnonymousParty,
-        override val amount: Amount<Issued<Transfer.DenomTrace>>
-): FungibleAsset<Transfer.DenomTrace> {
-    override val exitKeys: Collection<PublicKey> get() = setOf(owner.owningKey, amount.token.issuer.party.owningKey)
+        override val baseId: StateRef,
+        override val amount: Amount<Transfer.DenomTrace>,
+        override val owner: AbstractParty
+): IbcFungibleState<Transfer.DenomTrace>(), OwnableState {
+    override val participants get() = listOf(owner)
 
     override fun withNewOwner(newOwner: AbstractParty): CommandAndState {
-        throw NotImplementedError()
-    }
-    override fun withNewOwnerAndAmount(newAmount: Amount<Issued<Transfer.DenomTrace>>, newOwner: AbstractParty): FungibleAsset<Transfer.DenomTrace> {
         throw NotImplementedError()
     }
 }

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/Voucher.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics20cash/Voucher.kt
@@ -1,0 +1,25 @@
+package jp.datachain.corda.ibc.ics20cash
+
+import ibc.applications.transfer.v1.Transfer
+import jp.datachain.corda.ibc.contracts.Ibc
+import net.corda.core.contracts.*
+import net.corda.core.identity.AbstractParty
+import net.corda.core.serialization.CordaSerializable
+import java.security.PublicKey
+
+@BelongsToContract(Ibc::class)
+@CordaSerializable
+data class Voucher(
+        override val participants: List<AbstractParty>,
+        override val owner: AbstractParty,
+        override val amount: Amount<Issued<Transfer.DenomTrace>>
+): FungibleAsset<Transfer.DenomTrace> {
+    override val exitKeys: Collection<PublicKey> get() = setOf(owner.owningKey, amount.token.issuer.party.owningKey)
+
+    override fun withNewOwner(newOwner: AbstractParty): CommandAndState {
+        throw NotImplementedError()
+    }
+    override fun withNewOwnerAndAmount(newAmount: Amount<Issued<Transfer.DenomTrace>>, newOwner: AbstractParty): FungibleAsset<Transfer.DenomTrace> {
+        throw NotImplementedError()
+    }
+}

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics26/Context.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics26/Context.kt
@@ -1,40 +1,45 @@
 package jp.datachain.corda.ibc.ics26
 
 import jp.datachain.corda.ibc.states.IbcState
+import net.corda.core.contracts.ContractState
+import net.corda.core.contracts.hash
 
-class Context(val inStates: Collection<IbcState>, val refStates: Collection<IbcState>) {
-    val outStates = mutableSetOf<IbcState>()
+class Context(val inStates: Collection<ContractState>, val refStates: Collection<ContractState>) {
+    val outStates = mutableSetOf<ContractState>()
 
-    inline fun <reified T: IbcState> getInput(): T {
-        return inStates.filter{it is T}.single() as T
+    private val inIbcStates get() = inStates.mapNotNull{it as? IbcState}
+    private val refIbcStates get() = refStates.mapNotNull{it as? IbcState}
+    private val outIbcStates get() = outStates.mapNotNull{it as? IbcState}
+
+    inline fun <reified T: ContractState> getInputs(): List<T> {
+        return inStates.filterIsInstance<T>()
     }
+    inline fun <reified T: ContractState> getInput() = getInputs<T>().single()
+    inline fun <reified T: ContractState> getInputOrNull() = getInputs<T>().singleOrNull()
 
-    inline fun <reified T: IbcState> getInputOrNull(): T? {
-        return inStates.filter{it is T}.singleOrNull() as T?
+    inline fun <reified T: ContractState> getReferences(): List<T> {
+        return refStates.filterIsInstance<T>()
     }
+    inline fun <reified T: ContractState> getReference() = getReferences<T>().single()
 
-    inline fun <reified T: IbcState> getReference(): T {
-        return refStates.filter{it is T}.single() as T
-    }
-
-    inline fun <reified T: IbcState> addOutput(state: T) {
+    inline fun <reified T: ContractState> addOutput(state: T) {
         assert(outStates.none{it is T})
         outStates.add(state)
     }
 
-    fun verifyResults(expectedStates: Collection<IbcState>) {
+    fun verifyResults(expectedOutputStates: Collection<ContractState>) {
         // Confirm that output states are expected ones
-        require(expectedStates.map{it}.sortedBy{it.id}
-                == outStates.map{it}.sortedBy{it.id})
+        require(expectedOutputStates.size == outStates.size)
+        expectedOutputStates.forEach{require(outStates.contains(it)){"$it is not included in outStates"}}
 
         // Confirm that all input states are included in output states
-        require(outStates.map{it.linearId}.containsAll(
-                inStates.map{it.linearId}))
+        require(outIbcStates.map{it.linearId}.containsAll(
+                inIbcStates.map{it.linearId}))
 
         // Confirm all baseIds in states are same
-        val baseId = outStates.first().baseId
-        inStates.forEach{require(it.baseId == baseId)}
-        refStates.forEach{require(it.baseId == baseId)}
-        outStates.forEach{require(it.baseId == baseId)}
+        val baseId = outIbcStates.first().baseId
+        inIbcStates.forEach{require(it.baseId == baseId)}
+        refIbcStates.forEach{require(it.baseId == baseId)}
+        outIbcStates.forEach{require(it.baseId == baseId)}
     }
 }

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics26/Context.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics26/Context.kt
@@ -1,5 +1,6 @@
 package jp.datachain.corda.ibc.ics26
 
+import jp.datachain.corda.ibc.states.IbcFungibleState
 import jp.datachain.corda.ibc.states.IbcState
 import net.corda.core.contracts.ContractState
 import net.corda.core.contracts.hash
@@ -33,8 +34,8 @@ class Context(val inStates: Collection<ContractState>, val refStates: Collection
         expectedOutputStates.forEach{require(outStates.contains(it)){"$it is not included in outStates"}}
 
         // Confirm that all input states are included in output states
-        require(outIbcStates.map{it.linearId}.containsAll(
-                inIbcStates.map{it.linearId}))
+        require(outIbcStates.filter{it !is IbcFungibleState<*>}.map{it.linearId}.containsAll(
+                inIbcStates.filter{it !is IbcFungibleState<*>}.map{it.linearId}))
 
         // Confirm all baseIds in states are same
         val baseId = outIbcStates.first().baseId

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics26/ModuleCallbacks.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/ics26/ModuleCallbacks.kt
@@ -3,7 +3,8 @@ package jp.datachain.corda.ibc.ics26
 import ibc.core.channel.v1.ChannelOuterClass
 import ibc.core.connection.v1.Connection
 import jp.datachain.corda.ibc.ics24.Identifier
-import jp.datachain.corda.ibc.ics20.ModuleCallbacks as Ics20ModuleCallbacks
+//import jp.datachain.corda.ibc.ics20.ModuleCallbacks as Ics20ModuleCallbacks
+import jp.datachain.corda.ibc.ics20cash.ModuleCallbacks as Ics20ModuleCallbacks
 
 interface ModuleCallbacks {
     companion object {

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/serialization/DenomTraceSerializer.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/serialization/DenomTraceSerializer.kt
@@ -1,0 +1,12 @@
+package jp.datachain.corda.ibc.serialization
+
+import ibc.applications.transfer.v1.Transfer
+import net.corda.core.serialization.SerializationCustomSerializer
+import net.corda.core.utilities.OpaqueBytes
+
+class DenomTraceSerializer: SerializationCustomSerializer<Transfer.DenomTrace, DenomTraceSerializer.Proxy> {
+    data class Proxy(val serialized: OpaqueBytes)
+
+    override fun toProxy(obj: Transfer.DenomTrace) = Proxy(OpaqueBytes(obj.toByteArray() + 0))
+    override fun fromProxy(proxy: Proxy) = Transfer.DenomTrace.parseFrom(proxy.serialized.bytes.let { it.copyOf(it.size - 1) })!!
+}

--- a/contracts/src/main/kotlin/jp/datachain/corda/ibc/states/IbcFungibleState.kt
+++ b/contracts/src/main/kotlin/jp/datachain/corda/ibc/states/IbcFungibleState.kt
@@ -1,0 +1,8 @@
+package jp.datachain.corda.ibc.states
+
+import jp.datachain.corda.ibc.ics24.Identifier
+import net.corda.core.contracts.FungibleState
+
+abstract class IbcFungibleState<T: Any>: IbcState, FungibleState<T> {
+    override val id = Identifier("")
+}

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/BankService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/BankService.kt
@@ -26,9 +26,9 @@ class BankService(host: String, port: Int, username: String, password: String, p
     override fun allocateFund(request: BankProto.AllocateFundRequest, responseObserver: StreamObserver<Empty>) {
         ops.startFlow(::IbcFundAllocateFlow,
                 baseId,
-                Address(request.owner),
-                Denom(request.denom),
-                Amount(request.amount)
+                Address.fromBech32(request.owner),
+                Denom.fromString(request.denom),
+                Amount.fromString(request.amount)
         ).returnValue.get()
         responseObserver.onNext(Empty.getDefaultInstance())
         responseObserver.onCompleted()

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/BankService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/BankService.kt
@@ -5,8 +5,8 @@ import ibc.lightclients.corda.v1.BankProto
 import ibc.lightclients.corda.v1.BankServiceGrpc
 import io.grpc.stub.StreamObserver
 import jp.datachain.corda.ibc.conversion.into
-import jp.datachain.corda.ibc.flows.IbcBankCreateFlow
-import jp.datachain.corda.ibc.flows.IbcFundAllocateFlow
+import jp.datachain.corda.ibc.flows.ics20.IbcBankCreateFlow
+import jp.datachain.corda.ibc.flows.ics20.IbcFundAllocateFlow
 import jp.datachain.corda.ibc.ics20.Address
 import jp.datachain.corda.ibc.ics20.Amount
 import jp.datachain.corda.ibc.ics20.Bank

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/CashBankService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/CashBankService.kt
@@ -1,0 +1,54 @@
+package jp.datachain.corda.ibc.grpc_adapter
+
+import com.google.protobuf.Empty
+import ibc.lightclients.corda.v1.CashBankProto
+import ibc.lightclients.corda.v1.CashBankServiceGrpc
+import io.grpc.stub.StreamObserver
+import jp.datachain.corda.ibc.conversion.into
+import jp.datachain.corda.ibc.flows.ics20cash.IbcCashBankCreateFlow
+import jp.datachain.corda.ibc.ics20cash.CashBank
+import net.corda.core.contracts.Amount
+import net.corda.core.contracts.StateRef
+import net.corda.core.identity.Party
+import net.corda.core.messaging.startFlow
+import net.corda.core.messaging.vaultQueryBy
+import net.corda.core.node.services.vault.QueryCriteria
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.finance.flows.CashIssueAndPaymentFlow
+import java.util.*
+
+class CashBankService(host: String, port: Int, username: String, password: String, private val baseId: StateRef): CashBankServiceGrpc.CashBankServiceImplBase(), CordaRPCOpsReady by CordaRPCOpsReady.create(host, port, username, password) {
+    override fun createCashBank(request: CashBankProto.CreateCashBankRequest, responseObserver: StreamObserver<Empty>) {
+        ops.startFlow(::IbcCashBankCreateFlow, baseId, request.bank.into()).returnValue.get()
+        responseObserver.onNext(Empty.getDefaultInstance())
+        responseObserver.onCompleted()
+    }
+
+    private fun vaultQueryCashBank() = ops.vaultQueryBy<CashBank>(
+            QueryCriteria.LinearStateQueryCriteria(
+                    externalId = listOf(baseId.toString())
+            )
+    )
+
+    override fun allocateCash(request: CashBankProto.AllocateCashRequest, responseObserver: StreamObserver<Empty>) {
+        val notary = vaultQueryCashBank().statesMetadata.single().notary as Party
+        val flowRequest = CashIssueAndPaymentFlow.IssueAndPaymentRequest(
+                amount = Amount(
+                        request.amount.toLong(),
+                        Currency.getInstance(request.currency)
+                ),
+                issueRef = OpaqueBytes(ByteArray(1)),
+                recipient = request.owner.into(),
+                notary = notary,
+                anonymous = false)
+        ops.startFlow(::CashIssueAndPaymentFlow, flowRequest).returnValue.get()
+        responseObserver.onNext(Empty.getDefaultInstance())
+        responseObserver.onCompleted()
+    }
+
+    override fun queryCashBank(request: Empty, responseObserver: StreamObserver<CashBankProto.CashBank>) {
+        val reply: CashBankProto.CashBank = vaultQueryCashBank().states.single().state.data.into()
+        responseObserver.onNext(reply)
+        responseObserver.onCompleted()
+    }
+}

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/CashBankService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/CashBankService.kt
@@ -8,13 +8,13 @@ import jp.datachain.corda.ibc.conversion.into
 import jp.datachain.corda.ibc.flows.ics20cash.IbcCashBankCreateFlow
 import jp.datachain.corda.ibc.ics20.Address
 import jp.datachain.corda.ibc.ics20cash.CashBank
-import net.corda.core.contracts.Amount
 import net.corda.core.contracts.StateRef
 import net.corda.core.identity.Party
 import net.corda.core.messaging.startFlow
 import net.corda.core.messaging.vaultQueryBy
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.utilities.OpaqueBytes
+import net.corda.finance.AMOUNT
 import net.corda.finance.flows.CashIssueAndPaymentFlow
 import java.util.*
 
@@ -36,7 +36,7 @@ class CashBankService(host: String, port: Int, username: String, password: Strin
 
     override fun allocateCash(request: CashBankProto.AllocateCashRequest, responseObserver: StreamObserver<Empty>) {
         val flowRequest = CashIssueAndPaymentFlow.IssueAndPaymentRequest(
-                amount = Amount(
+                amount = AMOUNT(
                         request.amount.toLong(),
                         Currency.getInstance(request.currency)
                 ),

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/ChannelTxService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/ChannelTxService.kt
@@ -3,7 +3,7 @@ package jp.datachain.corda.ibc.grpc_adapter
 import ibc.core.channel.v1.MsgGrpc
 import ibc.core.channel.v1.Tx
 import io.grpc.stub.StreamObserver
-import jp.datachain.corda.ibc.flows.*
+import jp.datachain.corda.ibc.flows.ics4.*
 import net.corda.core.contracts.StateRef
 import net.corda.core.messaging.startFlow
 

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/Client.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/Client.kt
@@ -62,10 +62,10 @@ object Client {
         val genesisService = GenesisServiceGrpc.newBlockingStub(channel)
 
         val participants = listOf(partyName, "Notary").map {
-            nodeService.partiesFromName(Node.PartiesFromNameRequest.newBuilder()
+            nodeService.partyFromName(Node.PartyFromNameRequest.newBuilder()
                 .setName(it)
                 .setExactMatch(false)
-                .build()).partiesList.single()
+                .build()).party
         }
 
         val response = genesisService.createGenesis(Genesis.CreateGenesisRequest.newBuilder()

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/Client.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/Client.kt
@@ -426,10 +426,9 @@ object Client {
             transferTxServiceB.transfer(Tx.MsgTransfer.newBuilder().apply {
                 sourcePort = PORT_B
                 sourceChannel = CHANNEL_B
-                tokenBuilder.denom = Denom("USD")
-                        .addPrefix(Identifier(PORT_B), Identifier(CHANNEL_B))
-                        .ibcDenom
-                        .denom
+                tokenBuilder.denom = Denom.fromString("USD")
+                        .addPath(Identifier(PORT_B), Identifier(CHANNEL_B))
+                        .toIbcDenom()
                 tokenBuilder.amount = amount
                 sender = partyNameB
                 receiver = partyNameA

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/Client.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/Client.kt
@@ -37,7 +37,7 @@ object Client {
             "createHost" -> createHost(args[1])
             "createBank" -> createBank(args[1])
             "allocateFund" -> allocateFund(args[1], args[2])
-            "executeTest" -> executeTest(args[1], args[2], args[3], args[4])
+            "executeTest" -> executeTest(args[1], args[2], args[3], args[4], args[5])
         }
     }
 
@@ -110,11 +110,13 @@ object Client {
     private const val CHANNEL_VERSION_A = "CHANNEL_VERSION_A"
     private const val CHANNEL_VERSION_B = "CHANNEL_VERSION_B"
 
-    private fun executeTest(endpointA: String, endpointB: String, partyNameA: String, partyNameB: String) {
+    private fun executeTest(endpointA: String, endpointB: String, endpointBankA: String, partyNameA: String, partyNameB: String) {
         val channelA = connectGrpc(endpointA)
         val channelB = connectGrpc(endpointB)
+        val channelBankA = connectGrpc(endpointBankA)
 
         val hostServiceA = HostServiceGrpc.newBlockingStub(channelA)
+        val cashBankServiceA = CashBankServiceGrpc.newBlockingStub(channelA)
         val clientQueryServiceA = ClientQueryGrpc.newBlockingStub(channelA)
         val clientTxServiceA = ClientMsgGrpc.newBlockingStub(channelA)
         val connectionQueryServiceA = ConnectionQueryGrpc.newBlockingStub(channelA)
@@ -131,6 +133,9 @@ object Client {
         val channelQueryServiceB = ChannelQueryGrpc.newBlockingStub(channelB)
         val channelTxServiceB = ChannelMsgGrpc.newBlockingStub(channelB)
         val transferTxServiceB = TransferMsgGrpc.newBlockingStub(channelB)
+
+        val channelQueryServiceBankA = ChannelQueryGrpc.newBlockingStub(channelBankA)
+        val channelTxServiceBankA = ChannelMsgGrpc.newBlockingStub(channelBankA)
 
         val hostA = hostServiceA.queryHost(Empty.getDefaultInstance()).into()
         val consensusStateA = hostA.getConsensusState(hostA.getCurrentHeight())
@@ -282,6 +287,8 @@ object Client {
             proofHeight = chanAck.proofHeight
         }.build())
 
+        val baseDenom = "${cashBankServiceA.queryCashBank(Empty.getDefaultInstance()).owner.into().owningKey.encoded.toHex()}:USD"
+
         val pageReq = Pagination.PageRequest.newBuilder().apply{
             key = ByteString.copyFrom("", Charsets.US_ASCII)
             offset = 0
@@ -295,7 +302,7 @@ object Client {
             transferTxServiceA.transfer(Tx.MsgTransfer.newBuilder().apply {
                 sourcePort = PORT_A
                 sourceChannel = CHANNEL_A
-                tokenBuilder.denom = "USD"
+                tokenBuilder.denom = baseDenom
                 tokenBuilder.amount = amount
                 sender = partyNameA
                 receiver = partyNameB
@@ -418,15 +425,15 @@ object Client {
             }
         }
 
-        listOf(1, 58, 1).forEachIndexed { i, amount ->
+        listOf(1, 58, 1).forEachIndexed { i, quantity ->
             val seq = (i + 1).toLong()
-            val amount = amount.toString()
+            val amount = quantity.toString()
 
             // transfer back @ B
             transferTxServiceB.transfer(Tx.MsgTransfer.newBuilder().apply {
                 sourcePort = PORT_B
                 sourceChannel = CHANNEL_B
-                tokenBuilder.denom = Denom.fromString("USD")
+                tokenBuilder.denom = Denom.fromString(baseDenom)
                         .addPath(Identifier(PORT_B), Identifier(CHANNEL_B))
                         .toIbcDenom()
                 tokenBuilder.amount = amount
@@ -442,14 +449,14 @@ object Client {
                 channelId = CHANNEL_B
                 sequence = seq
             }.build())
-            channelTxServiceA.recvPacket(MsgRecvPacket.newBuilder().apply {
+            channelTxServiceBankA.recvPacket(MsgRecvPacket.newBuilder().apply {
                 packet = Packet.parseFrom(packetCommitment.commitment)
                 proof = packetCommitment.proof
                 proofHeight = packetCommitment.proofHeight
             }.build())
 
             // recv ack @ B
-            val packetAcknowledgement = channelQueryServiceA.packetAcknowledgement(QueryPacketAcknowledgementRequest.newBuilder().apply {
+            val packetAcknowledgement = channelQueryServiceBankA.packetAcknowledgement(QueryPacketAcknowledgementRequest.newBuilder().apply {
                 portId = PORT_A
                 channelId = CHANNEL_A
                 sequence = seq

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/ClientTxService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/ClientTxService.kt
@@ -3,7 +3,7 @@ package jp.datachain.corda.ibc.grpc_adapter
 import ibc.core.client.v1.Client
 import ibc.core.client.v1.MsgGrpc
 import io.grpc.stub.StreamObserver
-import jp.datachain.corda.ibc.flows.IbcClientCreateFlow
+import jp.datachain.corda.ibc.flows.ics2.IbcClientCreateFlow
 import net.corda.core.contracts.StateRef
 import net.corda.core.messaging.startFlow
 

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/ConnectionTxService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/ConnectionTxService.kt
@@ -3,7 +3,10 @@ package jp.datachain.corda.ibc.grpc_adapter
 import ibc.core.connection.v1.MsgGrpc
 import ibc.core.connection.v1.Tx
 import io.grpc.stub.StreamObserver
-import jp.datachain.corda.ibc.flows.*
+import jp.datachain.corda.ibc.flows.ics3.IbcConnOpenAckFlow
+import jp.datachain.corda.ibc.flows.ics3.IbcConnOpenConfirmFlow
+import jp.datachain.corda.ibc.flows.ics3.IbcConnOpenInitFlow
+import jp.datachain.corda.ibc.flows.ics3.IbcConnOpenTryFlow
 import net.corda.core.contracts.StateRef
 import net.corda.core.messaging.startFlow
 

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/GenesisService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/GenesisService.kt
@@ -4,7 +4,7 @@ import ibc.lightclients.corda.v1.Genesis
 import ibc.lightclients.corda.v1.GenesisServiceGrpc
 import io.grpc.stub.StreamObserver
 import jp.datachain.corda.ibc.conversion.into
-import jp.datachain.corda.ibc.flows.IbcGenesisCreateFlow
+import jp.datachain.corda.ibc.flows.ics24.IbcGenesisCreateFlow
 import net.corda.core.contracts.StateRef
 import net.corda.core.messaging.startFlow
 

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/HostService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/HostService.kt
@@ -5,7 +5,7 @@ import ibc.lightclients.corda.v1.HostProto
 import ibc.lightclients.corda.v1.HostServiceGrpc
 import io.grpc.stub.StreamObserver
 import jp.datachain.corda.ibc.conversion.into
-import jp.datachain.corda.ibc.flows.IbcHostCreateFlow
+import jp.datachain.corda.ibc.flows.ics24.IbcHostCreateFlow
 import jp.datachain.corda.ibc.ics24.Host
 import net.corda.core.contracts.StateRef
 import net.corda.core.messaging.startFlow

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/NodeService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/NodeService.kt
@@ -4,12 +4,23 @@ import ibc.lightclients.corda.v1.Node
 import ibc.lightclients.corda.v1.NodeServiceGrpc
 import io.grpc.stub.StreamObserver
 import jp.datachain.corda.ibc.conversion.into
+import jp.datachain.corda.ibc.ics20.Address
 
 class NodeService(host: String, port: Int, username: String, password: String): NodeServiceGrpc.NodeServiceImplBase(), CordaRPCOpsReady by CordaRPCOpsReady.create(host, port, username, password) {
-    override fun partiesFromName(request: Node.PartiesFromNameRequest, responseObserver: StreamObserver<Node.PartiesFromNameResponse>) {
-        val parties = ops.partiesFromName(request.name, request.exactMatch)
-        val response = Node.PartiesFromNameResponse.newBuilder()
-                .addAllParties(parties.map{it.into()})
+    override fun partyFromName(request: Node.PartyFromNameRequest, responseObserver: StreamObserver<Node.PartyFromNameResponse>) {
+        val party = ops.partiesFromName(request.name, request.exactMatch).single()
+        val response = Node.PartyFromNameResponse.newBuilder()
+                .setParty(party.into())
+                .build()
+        responseObserver.onNext(response)
+        responseObserver.onCompleted()
+    }
+
+    override fun addressFromName(request: Node.AddressFromNameRequest, responseObserver: StreamObserver<Node.AddressFromNameResponse>) {
+        val party = ops.partiesFromName(request.name, request.exactMatch).single()
+        val address = Address.fromPublicKey(party.owningKey).toBech32()
+        val response = Node.AddressFromNameResponse.newBuilder()
+                .setAddress(address)
                 .build()
         responseObserver.onNext(response)
         responseObserver.onCompleted()

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/Server.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/Server.kt
@@ -26,6 +26,7 @@ object Server {
         baseId?.let{
             opsReadyServices += HostService(hostname, port, username, password, it)
             opsReadyServices += BankService(hostname, port, username, password, it)
+            opsReadyServices += CashBankService(hostname, port, username, password, it)
 
             opsReadyServices += ClientTxService(hostname, port, username, password, it)
             opsReadyServices += ConnectionTxService(hostname, port, username, password, it)

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/TransferTxService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/TransferTxService.kt
@@ -3,13 +3,14 @@ package jp.datachain.corda.ibc.grpc_adapter
 import ibc.applications.transfer.v1.MsgGrpc
 import ibc.applications.transfer.v1.Tx
 import io.grpc.stub.StreamObserver
-import jp.datachain.corda.ibc.flows.ics20.IbcSendTransferFlow
+import jp.datachain.corda.ibc.flows.ics20cash.IbcTransferFlow
 import net.corda.core.contracts.StateRef
 import net.corda.core.messaging.startFlow
 
 class TransferTxService(host: String, port: Int, username: String, password: String, private val baseId: StateRef): MsgGrpc.MsgImplBase(), CordaRPCOpsReady by CordaRPCOpsReady.create(host, port, username, password) {
     override fun transfer(request: Tx.MsgTransfer, responseObserver: StreamObserver<Tx.MsgTransferResponse>) {
-        ops.startFlow(::IbcSendTransferFlow, baseId, request).returnValue.get()
+        //ops.startFlow(::IbcSendTransferFlow, baseId, request).returnValue.get()
+        ops.startFlow(::IbcTransferFlow, baseId, request).returnValue.get()
         responseObserver.onNext(Tx.MsgTransferResponse.getDefaultInstance())
         responseObserver.onCompleted()
     }

--- a/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/TransferTxService.kt
+++ b/grpc-adapter/src/main/kotlin/jp/datachain/corda/ibc/grpc_adapter/TransferTxService.kt
@@ -3,7 +3,7 @@ package jp.datachain.corda.ibc.grpc_adapter
 import ibc.applications.transfer.v1.MsgGrpc
 import ibc.applications.transfer.v1.Tx
 import io.grpc.stub.StreamObserver
-import jp.datachain.corda.ibc.flows.IbcSendTransferFlow
+import jp.datachain.corda.ibc.flows.ics20.IbcSendTransferFlow
 import net.corda.core.contracts.StateRef
 import net.corda.core.messaging.startFlow
 

--- a/proto/src/main/proto/ibc/lightclients/corda/v1/cash-bank.proto
+++ b/proto/src/main/proto/ibc/lightclients/corda/v1/cash-bank.proto
@@ -17,11 +17,11 @@ service CashBankService {
 }
 
 message CreateCashBankRequest {
-  Party bank = 1;
+  string bank_address = 1;
 }
 
 message AllocateCashRequest {
-  Party owner = 1;
+  string owner_address = 1;
   string currency = 2;
   string amount = 3;
 }

--- a/proto/src/main/proto/ibc/lightclients/corda/v1/cash-bank.proto
+++ b/proto/src/main/proto/ibc/lightclients/corda/v1/cash-bank.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+package ibc.lightclients.corda.v1;
+
+option go_package = "github.com/datachainlab/corda-ibc/go/x/ibc/light-clients/xx-corda/types";
+option java_outer_classname = "CashBankProto";
+
+import "ibc/lightclients/corda/v1/corda-types.proto";
+import "google/protobuf/empty.proto";
+
+service CashBankService {
+  // transactions
+  rpc CreateCashBank (CreateCashBankRequest) returns (google.protobuf.Empty);
+  rpc AllocateCash (AllocateCashRequest) returns (google.protobuf.Empty);
+
+  // queries
+  rpc QueryCashBank (google.protobuf.Empty) returns (CashBank);
+}
+
+message CreateCashBankRequest {
+  Party bank = 1;
+}
+
+message AllocateCashRequest {
+  Party owner = 1;
+  string currency = 2;
+  string amount = 3;
+}
+
+message CashBank {
+  message SupplyMap {
+    map<string, string> denomToAmount = 1;
+  }
+
+  message IbcDenomMap {
+    map<string, string> ibcDenomToDenom = 1;
+  }
+
+  repeated Party participants = 1;
+  StateRef baseId = 2;
+  Party owner = 3;
+  SupplyMap supply = 4;
+  IbcDenomMap denoms = 5;
+  string id = 6;
+}

--- a/proto/src/main/proto/ibc/lightclients/corda/v1/node.proto
+++ b/proto/src/main/proto/ibc/lightclients/corda/v1/node.proto
@@ -6,14 +6,24 @@ option go_package = "github.com/datachainlab/corda-ibc/go/x/ibc/light-clients/xx
 import "ibc/lightclients/corda/v1/corda-types.proto";
 
 service NodeService {
-  rpc PartiesFromName (PartiesFromNameRequest) returns (PartiesFromNameResponse);
+  rpc PartyFromName (PartyFromNameRequest) returns (PartyFromNameResponse);
+  rpc AddressFromName (AddressFromNameRequest) returns (AddressFromNameResponse);
 }
 
-message PartiesFromNameRequest {
+message PartyFromNameRequest {
   string name = 1;
   bool exact_match = 2;
 }
 
-message PartiesFromNameResponse {
-  repeated Party parties = 1;
+message PartyFromNameResponse {
+  Party party = 1;
+}
+
+message AddressFromNameRequest {
+  string name = 1;
+  bool exact_match = 2;
+}
+
+message AddressFromNameResponse {
+  string address = 1;
 }

--- a/rust/src/cash_bank.rs
+++ b/rust/src/cash_bank.rs
@@ -1,0 +1,42 @@
+use super::generated::ibc;
+use super::Result;
+use ibc::lightclients::corda::v1 as v1corda;
+
+async fn connect(
+    endpoint: String,
+) -> Result<v1corda::cash_bank_service_client::CashBankServiceClient<tonic::transport::Channel>> {
+    let client =
+        v1corda::cash_bank_service_client::CashBankServiceClient::connect(endpoint).await?;
+    Ok(client)
+}
+
+pub async fn create_cash_bank(endpoint: String, bank_address: String) -> Result<()> {
+    let mut client = connect(endpoint).await?;
+    client
+        .create_cash_bank(v1corda::CreateCashBankRequest { bank_address })
+        .await?;
+    Ok(())
+}
+
+pub async fn query_cash_bank(endpoint: String) -> Result<v1corda::CashBank> {
+    let mut client = connect(endpoint).await?;
+    let bank = client.query_cash_bank(()).await?;
+    Ok(bank.into_inner())
+}
+
+pub async fn allocate_cash(
+    endpoint: String,
+    owner_address: String,
+    currency: String,
+    amount: String,
+) -> Result<()> {
+    let mut client = connect(endpoint).await?;
+    client
+        .allocate_cash(v1corda::AllocateCashRequest {
+            owner_address,
+            currency,
+            amount,
+        })
+        .await?;
+    Ok(())
+}

--- a/rust/src/cash_bank_command.rs
+++ b/rust/src/cash_bank_command.rs
@@ -1,0 +1,51 @@
+use super::cash_bank;
+use super::Result;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum Opt {
+    CreateCashBank {
+        #[structopt(short, long, default_value = "http://localhost:9999")]
+        endpoint: String,
+
+        #[structopt(short, long)]
+        bank_address: String,
+    },
+    AllocateCash {
+        #[structopt(short, long, default_value = "http://localhost:9999")]
+        endpoint: String,
+
+        #[structopt(short, long)]
+        owner_address: String,
+
+        #[structopt(short, long)]
+        currency: String,
+
+        #[structopt(short, long)]
+        amount: String,
+    },
+    QueryCashBank {
+        #[structopt(short, long, default_value = "http://localhost:9999")]
+        endpoint: String,
+    },
+}
+
+pub async fn execute(opt: Opt) -> Result<()> {
+    match opt {
+        Opt::CreateCashBank {
+            endpoint,
+            bank_address,
+        } => cash_bank::create_cash_bank(endpoint, bank_address).await?,
+        Opt::AllocateCash {
+            endpoint,
+            owner_address,
+            currency,
+            amount,
+        } => cash_bank::allocate_cash(endpoint, owner_address, currency, amount).await?,
+        Opt::QueryCashBank { endpoint } => {
+            let host = cash_bank::query_cash_bank(endpoint).await?;
+            println!("{:?}", host);
+        }
+    }
+    Ok(())
+}

--- a/rust/src/genesis.rs
+++ b/rust/src/genesis.rs
@@ -1,36 +1,30 @@
 use super::generated::ibc;
+use super::node;
 use super::Result;
 use ibc::lightclients::corda::v1 as v1corda;
 
-pub async fn create_genesis(endpoint: String, party_name: String) -> Result<()> {
-    let participants = {
-        let mut client =
-            v1corda::node_service_client::NodeServiceClient::connect(endpoint.clone()).await?;
-        let mut participants = vec![];
-        for name in vec![String::from("Notary"), party_name] {
-            let mut parties = client
-                .parties_from_name(v1corda::PartiesFromNameRequest {
-                    name,
-                    exact_match: false,
-                })
-                .await?
-                .into_inner()
-                .parties;
-            assert!(parties.len() == 1);
-            participants.push(parties.remove(0));
-        }
-        participants
-    };
+async fn connect(
+    endpoint: String,
+) -> Result<v1corda::genesis_service_client::GenesisServiceClient<tonic::transport::Channel>> {
+    let client = v1corda::genesis_service_client::GenesisServiceClient::connect(endpoint).await?;
+    Ok(client)
+}
 
-    let base_id = {
-        let mut client =
-            v1corda::genesis_service_client::GenesisServiceClient::connect(endpoint).await?;
-        client
-            .create_genesis(v1corda::CreateGenesisRequest { participants })
-            .await?
-            .into_inner()
-            .base_id
-    };
+pub async fn create_genesis(endpoint: String, party_names: String) -> Result<()> {
+    let party_names: Vec<&str> = party_names.split(',').collect();
+    let mut participants = Vec::with_capacity(party_names.len());
+    for name in party_names.into_iter() {
+        eprintln!("get Party of {}", name);
+        let party = node::party_from_name(endpoint.clone(), name.to_string()).await?;
+        participants.push(party);
+    }
+
+    let mut client = connect(endpoint).await?;
+    let base_id = client
+        .create_genesis(v1corda::CreateGenesisRequest { participants })
+        .await?
+        .into_inner()
+        .base_id;
 
     let bash_hash = hex::encode(base_id.unwrap().txhash.unwrap().bytes);
     println!("{}", bash_hash);

--- a/rust/src/genesis_command.rs
+++ b/rust/src/genesis_command.rs
@@ -8,8 +8,8 @@ pub enum Opt {
         #[structopt(short, long, default_value = "http://localhost:9999")]
         endpoint: String,
 
-        #[structopt(short, long, default_value = "PartyA")]
-        party_name: String,
+        #[structopt(short, long)]
+        party_names: String,
     },
 }
 
@@ -17,8 +17,8 @@ pub async fn execute(opt: Opt) -> Result<()> {
     match opt {
         Opt::CreateGenesis {
             endpoint,
-            party_name,
-        } => genesis::create_genesis(endpoint, party_name).await?,
+            party_names,
+        } => genesis::create_genesis(endpoint, party_names).await?,
     }
     Ok(())
 }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -5,6 +5,8 @@ mod admin;
 mod admin_command;
 mod bank;
 mod bank_command;
+mod cash_bank;
+mod cash_bank_command;
 mod channel;
 mod channel_command;
 mod client;
@@ -17,6 +19,8 @@ mod genesis;
 mod genesis_command;
 mod host;
 mod host_command;
+mod node;
+mod node_command;
 mod util;
 
 use structopt::StructOpt;
@@ -30,9 +34,11 @@ enum Opt {
     Genesis(genesis_command::Opt),
     Host(host_command::Opt),
     Bank(bank_command::Opt),
+    CashBank(cash_bank_command::Opt),
     Client(client_command::Opt),
     Connection(connection_command::Opt),
     Channel(channel_command::Opt),
+    Node(node_command::Opt),
 }
 
 #[tokio::main]
@@ -42,9 +48,11 @@ async fn main() -> Result<()> {
         Opt::Genesis(opt) => genesis_command::execute(opt).await?,
         Opt::Host(opt) => host_command::execute(opt).await?,
         Opt::Bank(opt) => bank_command::execute(opt).await?,
+        Opt::CashBank(opt) => cash_bank_command::execute(opt).await?,
         Opt::Client(opt) => client_command::execute(opt).await?,
         Opt::Connection(opt) => connection_command::execute(opt).await?,
         Opt::Channel(opt) => channel_command::execute(opt).await?,
+        Opt::Node(opt) => node_command::execute(opt).await?,
     }
     Ok(())
 }

--- a/rust/src/node.rs
+++ b/rust/src/node.rs
@@ -1,0 +1,32 @@
+use super::generated::ibc;
+use super::Result;
+use ibc::lightclients::corda::v1 as v1corda;
+
+async fn connect(
+    endpoint: String,
+) -> Result<v1corda::node_service_client::NodeServiceClient<tonic::transport::Channel>> {
+    let client = v1corda::node_service_client::NodeServiceClient::connect(endpoint).await?;
+    Ok(client)
+}
+
+pub async fn party_from_name(endpoint: String, name: String) -> Result<v1corda::Party> {
+    let mut client = connect(endpoint).await?;
+    let response = client
+        .party_from_name(v1corda::PartyFromNameRequest {
+            name,
+            exact_match: false,
+        })
+        .await?;
+    Ok(response.into_inner().party.unwrap())
+}
+
+pub async fn address_from_name(endpoint: String, name: String) -> Result<String> {
+    let mut client = connect(endpoint).await?;
+    let response = client
+        .address_from_name(v1corda::AddressFromNameRequest {
+            name,
+            exact_match: false,
+        })
+        .await?;
+    Ok(response.into_inner().address)
+}

--- a/rust/src/node_command.rs
+++ b/rust/src/node_command.rs
@@ -1,0 +1,35 @@
+use super::node;
+use super::Result;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+pub enum Opt {
+    PartyFromName {
+        #[structopt(short, long, default_value = "http://localhost:9999")]
+        endpoint: String,
+
+        #[structopt(short, long)]
+        name: String,
+    },
+    AddressFromName {
+        #[structopt(short, long, default_value = "http://localhost:9999")]
+        endpoint: String,
+
+        #[structopt(short, long)]
+        name: String,
+    },
+}
+
+pub async fn execute(opt: Opt) -> Result<()> {
+    match opt {
+        Opt::PartyFromName { endpoint, name } => {
+            let party = node::party_from_name(endpoint, name).await?;
+            println!("{:?}", party);
+        }
+        Opt::AddressFromName { endpoint, name } => {
+            let address = node::address_from_name(endpoint, name).await?;
+            println!("{}", address);
+        }
+    }
+    Ok(())
+}

--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     // Corda dependencies.
     cordaCompile "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
+    cordaCompile "$corda_release_group:corda-finance-workflows:$corda_release_version"
 
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
 

--- a/workflows/build.gradle
+++ b/workflows/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     // Corda dependencies.
     cordaCompile "$corda_core_release_group:corda-core:$corda_core_release_version"
     cordaRuntime "$corda_release_group:corda:$corda_release_version"
-    cordaCompile "$corda_release_group:corda-finance-workflows:$corda_release_version"
+    cordapp("$corda_release_group:corda-finance-workflows:$corda_release_version")
 
     testCompile "$corda_release_group:corda-node-driver:$corda_release_version"
 

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics20/IbcFundAllocateFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics20/IbcFundAllocateFlow.kt
@@ -1,7 +1,8 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics20
 
 import co.paralleluniverse.fibers.Suspendable
 import jp.datachain.corda.ibc.contracts.Ibc
+import jp.datachain.corda.ibc.flows.util.queryIbcBank
 import jp.datachain.corda.ibc.ics20.Address
 import jp.datachain.corda.ibc.ics20.Amount
 import jp.datachain.corda.ibc.ics20.Denom
@@ -41,13 +42,12 @@ class IbcFundAllocateFlow(
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
 @InitiatedBy(IbcFundAllocateFlow::class)
-class IbcFundAllocateResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+class IbcFundAllocateResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics20cash/IbcCashBankCreateFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics20cash/IbcCashBankCreateFlow.kt
@@ -1,0 +1,52 @@
+package jp.datachain.corda.ibc.flows.ics20cash
+
+import co.paralleluniverse.fibers.Suspendable
+import jp.datachain.corda.ibc.contracts.Ibc
+import jp.datachain.corda.ibc.flows.util.queryIbcHost
+import jp.datachain.corda.ibc.ics20cash.CashBank
+import net.corda.core.contracts.StateRef
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+
+@StartableByRPC
+@InitiatingFlow
+class IbcCashBankCreateFlow(
+        private val baseId: StateRef,
+        private val bank: Party
+) : FlowLogic<SignedTransaction>() {
+    @Suspendable
+    override fun call() : SignedTransaction {
+        val notary = serviceHub.networkMapCache.notaryIdentities.single()
+
+        val builder = TransactionBuilder(notary)
+
+        val host = serviceHub.vaultService.queryIbcHost(baseId)!!
+        val participants = host.state.data.participants
+        require(participants.contains(ourIdentity))
+        require(participants.contains(bank))
+
+        val newBank = CashBank(host.state.data, bank)
+        val newHost = host.state.data.addBank(newBank.id)
+
+        builder.addCommand(Ibc.Commands.CashBankCreate(bank), ourIdentity.owningKey)
+                .addInputState(host)
+                .addOutputState(newHost)
+                .addOutputState(newBank)
+
+        val tx = serviceHub.signInitialTransaction(builder)
+
+        val sessions = (participants - ourIdentity).map{initiateFlow(it)}
+        return subFlow(FinalityFlow(tx, sessions))
+    }
+}
+
+@InitiatedBy(IbcCashBankCreateFlow::class)
+class IbcCashBankCreateResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        val stx = subFlow(ReceiveFinalityFlow(counterPartySession))
+        println(stx)
+    }
+}

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics20cash/IbcTransferFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics20cash/IbcTransferFlow.kt
@@ -1,0 +1,116 @@
+package jp.datachain.corda.ibc.flows.ics20cash
+
+import co.paralleluniverse.fibers.Suspendable
+import ibc.applications.transfer.v1.Transfer
+import ibc.applications.transfer.v1.Tx
+import jp.datachain.corda.ibc.flows.util.*
+import jp.datachain.corda.ibc.ics2.ClientState
+import jp.datachain.corda.ibc.ics20.Denom
+import jp.datachain.corda.ibc.ics20.hasPrefixes
+import jp.datachain.corda.ibc.ics20cash.HandleTransfer
+import jp.datachain.corda.ibc.ics20cash.Voucher
+import jp.datachain.corda.ibc.ics24.Identifier
+import jp.datachain.corda.ibc.ics26.Context
+import jp.datachain.corda.ibc.states.IbcChannel
+import jp.datachain.corda.ibc.states.IbcConnection
+import net.corda.core.contracts.*
+import net.corda.core.flows.*
+import net.corda.core.identity.Party
+import net.corda.core.transactions.SignedTransaction
+import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.finance.AMOUNT
+import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.issuedBy
+import java.util.*
+
+@StartableByRPC
+@InitiatingFlow
+class IbcTransferFlow(
+        private val baseId: StateRef,
+        private val msg: Tx.MsgTransfer
+) : FlowLogic<SignedTransaction>() {
+    @Suspendable
+    override fun call() : SignedTransaction {
+        val notary = serviceHub.networkMapCache.notaryIdentities.single()
+        val builder = TransactionBuilder(notary)
+
+        // query host from vault
+        val host = serviceHub.vaultService.queryIbcHost(baseId)!!
+        val participants = host.state.data.participants.map{it as Party}
+        require(participants.contains(ourIdentity))
+
+        // query chan from vault
+        val chan = serviceHub.vaultService.queryIbcState<IbcChannel>(baseId, Identifier(msg.sourceChannel))!!
+
+        // query conn from vault
+        val connId = Identifier(chan.state.data.end.connectionHopsList.single())
+        val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, connId)!!
+
+        // query client from vault
+        val clientId = Identifier(conn.state.data.end.clientId)
+        val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, clientId)!!
+
+        // query bank from vault
+        val bank = serviceHub.vaultService.queryIbcCashBank(baseId)!!
+
+        val inputs: MutableSet<StateAndRef<ContractState>> = mutableSetOf(chan, bank)
+        val refs = setOf(host, client, conn)
+
+        // prepare Cashes(or Vouchers) for inputs/outputs
+        val denom: Denom = msg.token.denom.let {
+            if (it.hasPrefixes("ibc")) {
+                bank.state.data.resolveDenom(it)
+            } else {
+                Denom.fromString(it)
+            }
+        }
+        val quantity = msg.token.amount.toLong()
+        if (!denom.isVoucher()) {
+            val amount = AMOUNT(quantity, denom.currency).issuedBy(PartyAndReference(bank.state.data.owner, OpaqueBytes(ByteArray(1))))
+            val coins = serviceHub.vaultService.prepareCoins<Cash.State, Issued<Currency>>(
+                    ownerKey = ourIdentity.owningKey,
+                    amount = amount)
+            require(coins.isNotEmpty())
+            inputs.addAll(coins)
+            builder.addCommand(Cash.Commands.Move(), ourIdentity.owningKey)
+        } else {
+            val amount = AMOUNT(quantity, denom.denomTrace)
+            val coins = serviceHub.vaultService.prepareCoins<Voucher, Transfer.DenomTrace>(
+                    ownerKey = ourIdentity.owningKey,
+                    amount = amount)
+            require(coins.isNotEmpty())
+            inputs.addAll(coins)
+        }
+
+        // execute command for obtaining outputs
+        val ctx = Context(
+                inputs.map{it.state.data},
+                refs.map{it.state.data}
+        )
+        val signers = listOf(ourIdentity.owningKey)
+        val command = HandleTransfer(msg)
+        command.execute(ctx, signers)
+
+        // build transaction
+        builder.addCommand(command, signers)
+        refs.forEach { builder.addReferenceState(ReferencedStateAndRef(it)) }
+        inputs.forEach { builder.addInputState(it) }
+        ctx.outStates.forEach { builder.addOutputState(it) }
+
+        // sign transaction (by initiator)
+        val tx = serviceHub.signInitialTransaction(builder)
+
+        val sessions = (participants - ourIdentity).map{initiateFlow(it)}
+        return subFlow(FinalityFlow(tx, sessions))
+    }
+}
+
+@InitiatedBy(IbcTransferFlow::class)
+class IbcTransferResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+    @Suspendable
+    override fun call() {
+        val stx = subFlow(ReceiveFinalityFlow(counterPartySession))
+        println(stx)
+    }
+}

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics24/IbcGenesisCreateFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics24/IbcGenesisCreateFlow.kt
@@ -1,4 +1,4 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics24
 
 import co.paralleluniverse.fibers.Suspendable
 import jp.datachain.corda.ibc.contracts.Ibc
@@ -10,7 +10,7 @@ import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 @InitiatingFlow
-class IbcGenesisCreateFlow(val participants: List<Party>) : FlowLogic<SignedTransaction>() {
+class IbcGenesisCreateFlow(private val participants: List<Party>) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
         require(participants.contains(ourIdentity))
@@ -25,13 +25,12 @@ class IbcGenesisCreateFlow(val participants: List<Party>) : FlowLogic<SignedTran
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
 @InitiatedBy(IbcGenesisCreateFlow::class)
-class IbcGenesisCreateResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+class IbcGenesisCreateResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics3/IbcConnOpenConfirmFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics3/IbcConnOpenConfirmFlow.kt
@@ -1,12 +1,13 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics3
 
 import co.paralleluniverse.fibers.Suspendable
-import ibc.core.channel.v1.Tx
+import ibc.core.connection.v1.Tx
+import jp.datachain.corda.ibc.flows.util.queryIbcHost
+import jp.datachain.corda.ibc.flows.util.queryIbcState
 import jp.datachain.corda.ibc.ics2.ClientState
 import jp.datachain.corda.ibc.ics24.Identifier
 import jp.datachain.corda.ibc.ics26.Context
-import jp.datachain.corda.ibc.ics26.HandleChanOpenTry
-import jp.datachain.corda.ibc.states.IbcChannel
+import jp.datachain.corda.ibc.ics26.HandleConnOpenConfirm
 import jp.datachain.corda.ibc.states.IbcConnection
 import net.corda.core.contracts.ReferencedStateAndRef
 import net.corda.core.contracts.StateRef
@@ -17,58 +18,45 @@ import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 @InitiatingFlow
-class IbcChanOpenTryFlow(
-        val baseId: StateRef,
-        val msg: Tx.MsgChannelOpenTry
+class IbcConnOpenConfirmFlow(
+        private val baseId: StateRef,
+        private val msg: Tx.MsgConnectionOpenConfirm
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
-        // query host from vault
+        // query host state
         val host = serviceHub.vaultService.queryIbcHost(baseId)!!
         val participants = host.state.data.participants.map{it as Party}
         require(participants.contains(ourIdentity))
 
-        // query conn from vault
-        val connId = Identifier(msg.channel.connectionHopsList.single())
-        val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, connId)!!
-
-        // query client from vault
-        val clientId = Identifier(conn.state.data.end.clientId)
-        val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, clientId)!!
-
-        // (optional) channel from vault
-        val chanOrNull = serviceHub.vaultService.queryIbcState<IbcChannel>(baseId, Identifier(msg.desiredChannelId))
+        // query conn state
+        val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, Identifier(msg.connectionId))!!
+        // query client state
+        val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, Identifier(conn.state.data.end.clientId))!!
 
         // create command and outputs
-        val command = HandleChanOpenTry(msg)
-        val inStates =
-                if(chanOrNull == null)
-                    setOf(host.state.data)
-                else
-                    setOf(host.state.data, chanOrNull.state.data)
-        val ctx = Context(inStates, setOf(client, conn).map{it.state.data})
+        val command = HandleConnOpenConfirm(msg)
+        val ctx = Context(setOf(conn.state.data), setOf(host, client).map{it.state.data})
         val signers = listOf(ourIdentity.owningKey)
         command.execute(ctx, signers)
 
         val notary = serviceHub.networkMapCache.notaryIdentities.single()
         val builder = TransactionBuilder(notary)
                 .addCommand(command, signers)
+                .addReferenceState(ReferencedStateAndRef(host))
                 .addReferenceState(ReferencedStateAndRef(client))
-                .addReferenceState(ReferencedStateAndRef(conn))
-                .addInputState(host)
-        chanOrNull?.let{builder.addInputState(it)}
+                .addInputState(conn)
         ctx.outStates.forEach{builder.addOutputState(it)}
 
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
-@InitiatedBy(IbcChanOpenTryFlow::class)
-class IbcChanOpenTryResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+@InitiatedBy(IbcConnOpenConfirmFlow::class)
+class IbcConnOpenConfirmResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics3/IbcConnOpenInitFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics3/IbcConnOpenInitFlow.kt
@@ -1,11 +1,13 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics3
 
 import co.paralleluniverse.fibers.Suspendable
-import ibc.core.channel.v1.Tx
+import ibc.core.connection.v1.Tx
+import jp.datachain.corda.ibc.flows.util.queryIbcHost
+import jp.datachain.corda.ibc.flows.util.queryIbcState
+import jp.datachain.corda.ibc.ics2.ClientState
 import jp.datachain.corda.ibc.ics24.Identifier
 import jp.datachain.corda.ibc.ics26.Context
-import jp.datachain.corda.ibc.ics26.HandleChanOpenInit
-import jp.datachain.corda.ibc.states.IbcConnection
+import jp.datachain.corda.ibc.ics26.HandleConnOpenInit
 import net.corda.core.contracts.ReferencedStateAndRef
 import net.corda.core.contracts.StateRef
 import net.corda.core.flows.*
@@ -15,45 +17,39 @@ import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 @InitiatingFlow
-class IbcChanOpenInitFlow(
-        val baseId: StateRef,
-        val msg: Tx.MsgChannelOpenInit
+class IbcConnOpenInitFlow(
+        private val baseId: StateRef,
+        private val msg: Tx.MsgConnectionOpenInit
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
-        // query host from vault
         val host = serviceHub.vaultService.queryIbcHost(baseId)!!
         val participants = host.state.data.participants.map{it as Party}
         require(participants.contains(ourIdentity))
 
-        // query connection from vault
-        val connId = Identifier(msg.channel.connectionHopsList.single())
-        val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, connId)!!
+        val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, Identifier(msg.clientId))!!
 
-        // create command and outputs
-        val command = HandleChanOpenInit(msg)
-        val ctx = Context(setOf(host.state.data), setOf(conn.state.data))
+        val command = HandleConnOpenInit(msg)
+        val ctx = Context(setOf(host.state.data), setOf(client.state.data))
         val signers = listOf(ourIdentity.owningKey)
         command.execute(ctx, signers)
 
-        // build tx
         val notary = serviceHub.networkMapCache.notaryIdentities.single()
         val builder = TransactionBuilder(notary)
-                .addCommand(command, signers)
+        builder.addCommand(command, ourIdentity.owningKey)
                 .addInputState(host)
-                .addReferenceState(ReferencedStateAndRef(conn))
+                .addReferenceState(ReferencedStateAndRef(client))
         ctx.outStates.forEach{builder.addOutputState(it)}
 
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
-@InitiatedBy(IbcChanOpenInitFlow::class)
-class IbcChanOpenInitResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+@InitiatedBy(IbcConnOpenInitFlow::class)
+class IbcConnOpenInitResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics3/IbcConnOpenTryFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics3/IbcConnOpenTryFlow.kt
@@ -1,12 +1,13 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics3
 
 import co.paralleluniverse.fibers.Suspendable
-import ibc.core.channel.v1.Tx
+import ibc.core.connection.v1.Tx
+import jp.datachain.corda.ibc.flows.util.queryIbcHost
+import jp.datachain.corda.ibc.flows.util.queryIbcState
 import jp.datachain.corda.ibc.ics2.ClientState
 import jp.datachain.corda.ibc.ics24.Identifier
 import jp.datachain.corda.ibc.ics26.Context
-import jp.datachain.corda.ibc.ics26.HandleChanOpenAck
-import jp.datachain.corda.ibc.states.IbcChannel
+import jp.datachain.corda.ibc.ics26.HandleConnOpenTry
 import jp.datachain.corda.ibc.states.IbcConnection
 import net.corda.core.contracts.ReferencedStateAndRef
 import net.corda.core.contracts.StateRef
@@ -17,54 +18,50 @@ import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 @InitiatingFlow
-class IbcChanOpenAckFlow(
-        val baseId: StateRef,
-        val msg: Tx.MsgChannelOpenAck
+class IbcConnOpenTryFlow(
+        private val baseId: StateRef,
+        private val msg: Tx.MsgConnectionOpenTry
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
-        // query host from vault
+        // query host state
         val host = serviceHub.vaultService.queryIbcHost(baseId)!!
         val participants = host.state.data.participants.map{it as Party}
         require(participants.contains(ourIdentity))
 
-        // query chan from vault
-        val chan = serviceHub.vaultService.queryIbcState<IbcChannel>(baseId, Identifier(msg.channelId))!!
+        // query client state
+        val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, Identifier(msg.clientId))!!
 
-        // query conn from vault
-        val connId = Identifier(chan.state.data.end.connectionHopsList.single())
-        val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, connId)!!
+        // query conn state
+        val connOrNull = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, Identifier(msg.desiredConnectionId))
 
-        // query client from vault
-        val clientId = Identifier(conn.state.data.end.clientId)
-        val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, clientId)!!
-
-        // create command and outputs
-        val command = HandleChanOpenAck(msg)
-        val ctx = Context(setOf(chan.state.data), setOf(host, client, conn).map{it.state.data})
+        val command = HandleConnOpenTry(msg)
+        val inStates =
+                if (connOrNull == null)
+                    setOf(host.state.data)
+                else
+                    setOf(host.state.data, connOrNull.state.data)
+        val ctx = Context(inStates, setOf(client.state.data))
         val signers = listOf(ourIdentity.owningKey)
         command.execute(ctx, signers)
 
-        // build tx
         val notary = serviceHub.networkMapCache.notaryIdentities.single()
         val builder = TransactionBuilder(notary)
                 .addCommand(command, signers)
-                .addReferenceState(ReferencedStateAndRef(host))
+                .addInputState(host)
                 .addReferenceState(ReferencedStateAndRef(client))
-                .addReferenceState(ReferencedStateAndRef(conn))
-                .addInputState(chan)
+        connOrNull?.let{builder.addInputState(it)}
         ctx.outStates.forEach{builder.addOutputState(it)}
 
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
-@InitiatedBy(IbcChanOpenAckFlow::class)
-class IbcChanOpenAckResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+@InitiatedBy(IbcConnOpenTryFlow::class)
+class IbcConnOpenTryResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcAcknowledgePacketFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcAcknowledgePacketFlow.kt
@@ -2,7 +2,7 @@ package jp.datachain.corda.ibc.flows.ics4
 
 import co.paralleluniverse.fibers.Suspendable
 import ibc.core.channel.v1.Tx
-import jp.datachain.corda.ibc.flows.util.queryIbcBank
+import jp.datachain.corda.ibc.flows.util.queryIbcCashBank
 import jp.datachain.corda.ibc.flows.util.queryIbcHost
 import jp.datachain.corda.ibc.flows.util.queryIbcState
 import jp.datachain.corda.ibc.ics2.ClientState
@@ -32,9 +32,9 @@ class IbcAcknowledgePacketFlow(
         require(participants.contains(ourIdentity))
 
         // query bank if necessary
-        val bankOrNull =
+        val cashBankOrNull =
                 if (msg.packet.destinationPort == "transfer")
-                    serviceHub.vaultService.queryIbcBank(baseId)!!
+                    serviceHub.vaultService.queryIbcCashBank(baseId)!!
                 else
                     null
 
@@ -53,8 +53,8 @@ class IbcAcknowledgePacketFlow(
         // create command and outputs
         val command = HandlePacketAcknowledgement(msg)
         val ctx = Context(
-                if (bankOrNull != null) {
-                    setOf(chan.state.data, bankOrNull.state.data)
+                if (cashBankOrNull != null) {
+                    setOf(chan.state.data, cashBankOrNull.state.data)
                 } else {
                     setOf(chan.state.data)
                 },
@@ -71,7 +71,7 @@ class IbcAcknowledgePacketFlow(
                 .addReferenceState(ReferencedStateAndRef(client))
                 .addReferenceState(ReferencedStateAndRef(conn))
                 .addInputState(chan)
-        bankOrNull?.let{builder.addInputState(it)}
+        cashBankOrNull?.let{builder.addInputState(it)}
         ctx.outStates.forEach{builder.addOutputState(it)}
 
         val tx = serviceHub.signInitialTransaction(builder)

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcAcknowledgePacketFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcAcknowledgePacketFlow.kt
@@ -1,11 +1,14 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics4
 
 import co.paralleluniverse.fibers.Suspendable
 import ibc.core.channel.v1.Tx
+import jp.datachain.corda.ibc.flows.util.queryIbcBank
+import jp.datachain.corda.ibc.flows.util.queryIbcHost
+import jp.datachain.corda.ibc.flows.util.queryIbcState
 import jp.datachain.corda.ibc.ics2.ClientState
 import jp.datachain.corda.ibc.ics24.Identifier
 import jp.datachain.corda.ibc.ics26.Context
-import jp.datachain.corda.ibc.ics26.HandleChanOpenConfirm
+import jp.datachain.corda.ibc.ics26.HandlePacketAcknowledgement
 import jp.datachain.corda.ibc.states.IbcChannel
 import jp.datachain.corda.ibc.states.IbcConnection
 import net.corda.core.contracts.ReferencedStateAndRef
@@ -17,9 +20,9 @@ import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 @InitiatingFlow
-class IbcChanOpenConfirmFlow(
-        val baseId: StateRef,
-        val msg: Tx.MsgChannelOpenConfirm
+class IbcAcknowledgePacketFlow(
+        private val baseId: StateRef,
+        private val msg: Tx.MsgAcknowledgement
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
@@ -28,8 +31,16 @@ class IbcChanOpenConfirmFlow(
         val participants = host.state.data.participants.map{it as Party}
         require(participants.contains(ourIdentity))
 
+        // query bank if necessary
+        val bankOrNull =
+                if (msg.packet.destinationPort == "transfer")
+                    serviceHub.vaultService.queryIbcBank(baseId)!!
+                else
+                    null
+
         // query chan from vault
-        val chan = serviceHub.vaultService.queryIbcState<IbcChannel>(baseId, Identifier(msg.channelId))!!
+        val chanId = Identifier(msg.packet.sourceChannel)
+        val chan = serviceHub.vaultService.queryIbcState<IbcChannel>(baseId, chanId)!!
 
         // query conn from vault
         val connId = Identifier(chan.state.data.end.connectionHopsList.single())
@@ -40,11 +51,19 @@ class IbcChanOpenConfirmFlow(
         val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, clientId)!!
 
         // create command and outputs
-        val command = HandleChanOpenConfirm(msg)
-        val ctx = Context(setOf(chan.state.data), setOf(host, client, conn).map{it.state.data})
+        val command = HandlePacketAcknowledgement(msg)
+        val ctx = Context(
+                if (bankOrNull != null) {
+                    setOf(chan.state.data, bankOrNull.state.data)
+                } else {
+                    setOf(chan.state.data)
+                },
+                setOf(host, client, conn).map{it.state.data}
+        )
         val signers = listOf(ourIdentity.owningKey)
         command.execute(ctx, signers)
 
+        // build tx
         val notary = serviceHub.networkMapCache.notaryIdentities.single()
         val builder = TransactionBuilder(notary)
                 .addCommand(command, signers)
@@ -52,18 +71,18 @@ class IbcChanOpenConfirmFlow(
                 .addReferenceState(ReferencedStateAndRef(client))
                 .addReferenceState(ReferencedStateAndRef(conn))
                 .addInputState(chan)
+        bankOrNull?.let{builder.addInputState(it)}
         ctx.outStates.forEach{builder.addOutputState(it)}
 
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
-@InitiatedBy(IbcChanOpenConfirmFlow::class)
-class IbcChanOpenConfirmResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+@InitiatedBy(IbcAcknowledgePacketFlow::class)
+class IbcAcknowledgePacketResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcChanCloseInitFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcChanCloseInitFlow.kt
@@ -1,11 +1,12 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics4
 
 import co.paralleluniverse.fibers.Suspendable
 import ibc.core.channel.v1.Tx
-import jp.datachain.corda.ibc.ics2.ClientState
+import jp.datachain.corda.ibc.flows.util.queryIbcHost
+import jp.datachain.corda.ibc.flows.util.queryIbcState
 import jp.datachain.corda.ibc.ics24.Identifier
 import jp.datachain.corda.ibc.ics26.Context
-import jp.datachain.corda.ibc.ics26.HandleChanCloseConfirm
+import jp.datachain.corda.ibc.ics26.HandleChanCloseInit
 import jp.datachain.corda.ibc.states.IbcChannel
 import jp.datachain.corda.ibc.states.IbcConnection
 import net.corda.core.contracts.ReferencedStateAndRef
@@ -17,9 +18,9 @@ import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 @InitiatingFlow
-class IbcChanCloseConfirmFlow(
-        val baseId: StateRef,
-        val msg: Tx.MsgChannelCloseConfirm
+class IbcChanCloseInitFlow(
+        private val baseId: StateRef,
+        private val msg: Tx.MsgChannelCloseInit
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
@@ -28,20 +29,16 @@ class IbcChanCloseConfirmFlow(
         val participants = host.state.data.participants.map{it as Party}
         require(participants.contains(ourIdentity))
 
-        // query chan from vault
+        // query channel from vault
         val chan = serviceHub.vaultService.queryIbcState<IbcChannel>(baseId, Identifier(msg.channelId))!!
 
-        // query conn from vault
+        // query connection from vault
         val connId = Identifier(chan.state.data.end.connectionHopsList.single())
         val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, connId)!!
 
-        // query client from vault
-        val clientId = Identifier(conn.state.data.end.clientId)
-        val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, clientId)!!
-
         // create command and outputs
-        val command = HandleChanCloseConfirm(msg)
-        val ctx = Context(setOf(chan.state.data), setOf(host, client, conn).map{it.state.data})
+        val command = HandleChanCloseInit(msg)
+        val ctx = Context(setOf(chan.state.data), setOf(host, conn).map{it.state.data})
         val signers = listOf(ourIdentity.owningKey)
         command.execute(ctx, signers)
 
@@ -50,7 +47,6 @@ class IbcChanCloseConfirmFlow(
         val builder = TransactionBuilder(notary)
                 .addCommand(command, signers)
                 .addReferenceState(ReferencedStateAndRef(host))
-                .addReferenceState(ReferencedStateAndRef(client))
                 .addReferenceState(ReferencedStateAndRef(conn))
                 .addInputState(chan)
         ctx.outStates.forEach{builder.addOutputState(it)}
@@ -58,13 +54,12 @@ class IbcChanCloseConfirmFlow(
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
-@InitiatedBy(IbcChanCloseConfirmFlow::class)
-class IbcChanCloseConfirmResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+@InitiatedBy(IbcChanCloseInitFlow::class)
+class IbcChanCloseInitResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcChanOpenInitFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcChanOpenInitFlow.kt
@@ -1,11 +1,12 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics4
 
 import co.paralleluniverse.fibers.Suspendable
-import ibc.core.connection.v1.Tx
-import jp.datachain.corda.ibc.ics2.ClientState
+import ibc.core.channel.v1.Tx
+import jp.datachain.corda.ibc.flows.util.queryIbcHost
+import jp.datachain.corda.ibc.flows.util.queryIbcState
 import jp.datachain.corda.ibc.ics24.Identifier
 import jp.datachain.corda.ibc.ics26.Context
-import jp.datachain.corda.ibc.ics26.HandleConnOpenConfirm
+import jp.datachain.corda.ibc.ics26.HandleChanOpenInit
 import jp.datachain.corda.ibc.states.IbcConnection
 import net.corda.core.contracts.ReferencedStateAndRef
 import net.corda.core.contracts.StateRef
@@ -16,46 +17,44 @@ import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 @InitiatingFlow
-class IbcConnOpenConfirmFlow(
-        val baseId: StateRef,
-        val msg: Tx.MsgConnectionOpenConfirm
+class IbcChanOpenInitFlow(
+        private val baseId: StateRef,
+        private val msg: Tx.MsgChannelOpenInit
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
-        // query host state
+        // query host from vault
         val host = serviceHub.vaultService.queryIbcHost(baseId)!!
         val participants = host.state.data.participants.map{it as Party}
         require(participants.contains(ourIdentity))
 
-        // query conn state
-        val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, Identifier(msg.connectionId))!!
-        // query client state
-        val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, Identifier(conn.state.data.end.clientId))!!
+        // query connection from vault
+        val connId = Identifier(msg.channel.connectionHopsList.single())
+        val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, connId)!!
 
         // create command and outputs
-        val command = HandleConnOpenConfirm(msg)
-        val ctx = Context(setOf(conn.state.data), setOf(host, client).map{it.state.data})
+        val command = HandleChanOpenInit(msg)
+        val ctx = Context(setOf(host.state.data), setOf(conn.state.data))
         val signers = listOf(ourIdentity.owningKey)
         command.execute(ctx, signers)
 
+        // build tx
         val notary = serviceHub.networkMapCache.notaryIdentities.single()
         val builder = TransactionBuilder(notary)
                 .addCommand(command, signers)
-                .addReferenceState(ReferencedStateAndRef(host))
-                .addReferenceState(ReferencedStateAndRef(client))
-                .addInputState(conn)
+                .addInputState(host)
+                .addReferenceState(ReferencedStateAndRef(conn))
         ctx.outStates.forEach{builder.addOutputState(it)}
 
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
-@InitiatedBy(IbcConnOpenConfirmFlow::class)
-class IbcConnOpenConfirmResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+@InitiatedBy(IbcChanOpenInitFlow::class)
+class IbcChanOpenInitResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcRecvPacketFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcRecvPacketFlow.kt
@@ -1,12 +1,14 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.ics4
 
 import co.paralleluniverse.fibers.Suspendable
-import ibc.core.channel.v1.ChannelOuterClass
-import jp.datachain.corda.ibc.contracts.Ibc
+import ibc.core.channel.v1.Tx
+import jp.datachain.corda.ibc.flows.util.queryIbcBank
+import jp.datachain.corda.ibc.flows.util.queryIbcHost
+import jp.datachain.corda.ibc.flows.util.queryIbcState
 import jp.datachain.corda.ibc.ics2.ClientState
 import jp.datachain.corda.ibc.ics24.Identifier
-import jp.datachain.corda.ibc.ics25.Handler
 import jp.datachain.corda.ibc.ics26.Context
+import jp.datachain.corda.ibc.ics26.HandlePacketRecv
 import jp.datachain.corda.ibc.states.IbcChannel
 import jp.datachain.corda.ibc.states.IbcConnection
 import net.corda.core.contracts.ReferencedStateAndRef
@@ -18,23 +20,26 @@ import net.corda.core.transactions.TransactionBuilder
 
 @StartableByRPC
 @InitiatingFlow
-class IbcSendPacketFlow(
-        val baseId: StateRef,
-        val packet: ChannelOuterClass.Packet
+class IbcRecvPacketFlow(
+        private val baseId: StateRef,
+        private val msg: Tx.MsgRecvPacket
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
-        val notary = serviceHub.networkMapCache.notaryIdentities.single()
-
-        val builder = TransactionBuilder(notary)
-
         // query host from vault
         val host = serviceHub.vaultService.queryIbcHost(baseId)!!
         val participants = host.state.data.participants.map{it as Party}
         require(participants.contains(ourIdentity))
 
+        // query bank if necessary
+        val bankOrNull =
+                if (msg.packet.destinationPort == "transfer")
+                    serviceHub.vaultService.queryIbcBank(baseId)!!
+                else
+                    null
+
         // query chan from vault
-        val chanId = Identifier(packet.sourceChannel)
+        val chanId = Identifier(msg.packet.destinationChannel)
         val chan = serviceHub.vaultService.queryIbcState<IbcChannel>(baseId, chanId)!!
 
         // query conn from vault
@@ -45,26 +50,39 @@ class IbcSendPacketFlow(
         val clientId = Identifier(conn.state.data.end.clientId)
         val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, clientId)!!
 
-        val ctx = Context(setOf(chan.state.data), setOf(host.state.data, client.state.data, conn.state.data))
-        Handler.sendPacket(ctx, packet)
+        // create command and outputs
+        val command = HandlePacketRecv(msg)
+        val ctx = Context(
+                if (bankOrNull != null) {
+                    setOf(chan.state.data, bankOrNull.state.data)
+                } else {
+                    setOf(chan.state.data)
+                },
+                setOf(host, client, conn).map{it.state.data}
+        )
+        val signers = listOf(ourIdentity.owningKey)
+        command.execute(ctx, signers)
 
-        builder.addCommand(Ibc.Commands.SendPacket(packet), ourIdentity.owningKey)
+        // build tx
+        val notary = serviceHub.networkMapCache.notaryIdentities.single()
+        val builder = TransactionBuilder(notary)
+                .addCommand(command, signers)
                 .addReferenceState(ReferencedStateAndRef(host))
                 .addReferenceState(ReferencedStateAndRef(client))
                 .addReferenceState(ReferencedStateAndRef(conn))
                 .addInputState(chan)
+        bankOrNull?.let{builder.addInputState(it)}
         ctx.outStates.forEach{builder.addOutputState(it)}
 
         val tx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        val stx = subFlow(FinalityFlow(tx, sessions))
-        return stx
+        return subFlow(FinalityFlow(tx, sessions))
     }
 }
 
-@InitiatedBy(IbcSendPacketFlow::class)
-class IbcSendPacketResponderFlow(val counterPartySession: FlowSession) : FlowLogic<Unit>() {
+@InitiatedBy(IbcRecvPacketFlow::class)
+class IbcRecvPacketResponderFlow(private val counterPartySession: FlowSession) : FlowLogic<Unit>() {
     @Suspendable
     override fun call() {
         val stx = subFlow(ReceiveFinalityFlow(counterPartySession))

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcRecvPacketFlow.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/ics4/IbcRecvPacketFlow.kt
@@ -2,21 +2,32 @@ package jp.datachain.corda.ibc.flows.ics4
 
 import co.paralleluniverse.fibers.Suspendable
 import ibc.core.channel.v1.Tx
-import jp.datachain.corda.ibc.flows.util.queryIbcBank
+import jp.datachain.corda.ibc.flows.util.prepareCoins
+import jp.datachain.corda.ibc.flows.util.queryIbcCashBank
 import jp.datachain.corda.ibc.flows.util.queryIbcHost
 import jp.datachain.corda.ibc.flows.util.queryIbcState
 import jp.datachain.corda.ibc.ics2.ClientState
+import jp.datachain.corda.ibc.ics20.Denom
+import jp.datachain.corda.ibc.ics20.hasPrefixes
+import jp.datachain.corda.ibc.ics20.toFungibleTokenPacketData
+import jp.datachain.corda.ibc.ics20cash.CashBank
 import jp.datachain.corda.ibc.ics24.Identifier
 import jp.datachain.corda.ibc.ics26.Context
 import jp.datachain.corda.ibc.ics26.HandlePacketRecv
 import jp.datachain.corda.ibc.states.IbcChannel
 import jp.datachain.corda.ibc.states.IbcConnection
-import net.corda.core.contracts.ReferencedStateAndRef
-import net.corda.core.contracts.StateRef
+import net.corda.core.contracts.*
 import net.corda.core.flows.*
 import net.corda.core.identity.Party
+import net.corda.core.internal.noneOrSingle
 import net.corda.core.transactions.SignedTransaction
 import net.corda.core.transactions.TransactionBuilder
+import net.corda.core.utilities.OpaqueBytes
+import net.corda.core.utilities.UntrustworthyData
+import net.corda.finance.AMOUNT
+import net.corda.finance.contracts.asset.Cash
+import net.corda.finance.issuedBy
+import java.util.*
 
 @StartableByRPC
 @InitiatingFlow
@@ -26,58 +37,72 @@ class IbcRecvPacketFlow(
 ) : FlowLogic<SignedTransaction>() {
     @Suspendable
     override fun call() : SignedTransaction {
+        val notary = serviceHub.networkMapCache.notaryIdentities.single()
+        val builder = TransactionBuilder(notary)
+
+        val inputs = mutableListOf<StateAndRef<ContractState>>()
+        val refs = mutableListOf<StateAndRef<ContractState>>()
+
         // query host from vault
         val host = serviceHub.vaultService.queryIbcHost(baseId)!!
+        refs.add(host)
+
+        // check participants
         val participants = host.state.data.participants.map{it as Party}
         require(participants.contains(ourIdentity))
 
-        // query bank if necessary
-        val bankOrNull =
-                if (msg.packet.destinationPort == "transfer")
-                    serviceHub.vaultService.queryIbcBank(baseId)!!
-                else
-                    null
+        // states specific to ICS-20
+        if (msg.packet.destinationPort == "transfer") {
+            val cashBank = serviceHub.vaultService.queryIbcCashBank(baseId)!!
+            inputs.add(cashBank)
+
+            val packet = msg.packet.data.toFungibleTokenPacketData()
+            val denom = Denom.fromString(packet.denom)
+            val source = denom.hasPrefix(Identifier(msg.packet.sourcePort), Identifier(msg.packet.sourceChannel))
+            if (source && !denom.removePrefix().isVoucher()) {
+                val denom = denom.removePrefix()
+                val issuer = serviceHub.identityService.partyFromKey(denom.issuerKey)!!
+                val amount = AMOUNT(packet.amount, denom.currency).issuedBy(PartyAndReference(issuer, OpaqueBytes(ByteArray(1))))
+                val coins = serviceHub.vaultService.prepareCoins<Cash.State, Issued<Currency>>(
+                        ownerKey = cashBank.state.data.owner.owningKey,
+                        amount = amount)
+                require(coins.isNotEmpty())
+                inputs.addAll(coins)
+                builder.addCommand(Cash.Commands.Move(), cashBank.state.data.owner.owningKey)
+            }
+        }
 
         // query chan from vault
         val chanId = Identifier(msg.packet.destinationChannel)
         val chan = serviceHub.vaultService.queryIbcState<IbcChannel>(baseId, chanId)!!
+        inputs.add(chan)
 
         // query conn from vault
         val connId = Identifier(chan.state.data.end.connectionHopsList.single())
         val conn = serviceHub.vaultService.queryIbcState<IbcConnection>(baseId, connId)!!
+        refs.add(conn)
 
         // query client from vault
         val clientId = Identifier(conn.state.data.end.clientId)
         val client = serviceHub.vaultService.queryIbcState<ClientState>(baseId, clientId)!!
+        refs.add(client)
 
         // create command and outputs
         val command = HandlePacketRecv(msg)
-        val ctx = Context(
-                if (bankOrNull != null) {
-                    setOf(chan.state.data, bankOrNull.state.data)
-                } else {
-                    setOf(chan.state.data)
-                },
-                setOf(host, client, conn).map{it.state.data}
-        )
+        val ctx = Context(inputs.map{it.state.data}, refs.map{it.state.data})
         val signers = listOf(ourIdentity.owningKey)
         command.execute(ctx, signers)
 
         // build tx
-        val notary = serviceHub.networkMapCache.notaryIdentities.single()
-        val builder = TransactionBuilder(notary)
-                .addCommand(command, signers)
-                .addReferenceState(ReferencedStateAndRef(host))
-                .addReferenceState(ReferencedStateAndRef(client))
-                .addReferenceState(ReferencedStateAndRef(conn))
-                .addInputState(chan)
-        bankOrNull?.let{builder.addInputState(it)}
+        builder.addCommand(command, signers)
+        refs.forEach{builder.addReferenceState(ReferencedStateAndRef(it))}
+        inputs.forEach{builder.addInputState(it)}
         ctx.outStates.forEach{builder.addOutputState(it)}
 
-        val tx = serviceHub.signInitialTransaction(builder)
+        val stx = serviceHub.signInitialTransaction(builder)
 
         val sessions = (participants - ourIdentity).map{initiateFlow(it)}
-        return subFlow(FinalityFlow(tx, sessions))
+        return subFlow(FinalityFlow(stx, sessions))
     }
 }
 

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/util/prepare-spend.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/util/prepare-spend.kt
@@ -1,0 +1,31 @@
+package jp.datachain.corda.ibc.flows.util
+
+import net.corda.core.contracts.*
+import net.corda.core.node.services.VaultService
+import net.corda.core.node.services.queryBy
+import java.security.PublicKey
+
+inline fun <reified S, reified T: Any>VaultService.prepareCoins(
+        ownerKey: PublicKey,
+        amount: Amount<T>
+): List<StateAndRef<S>>
+        where S: FungibleState<T>,
+              S: OwnableState
+{
+    val allCoins = this.queryBy<S>().states
+            .filter { it.state.data.owner.owningKey == ownerKey && it.state.data.amount.token == amount.token }
+            .sortedBy { it.state.data.amount } // ascending order
+    val inputs = mutableListOf<StateAndRef<S>>()
+    var collected = amount.copy(quantity = 0)
+    for (coin in allCoins) {
+        inputs.add(coin)
+        collected += coin.state.data.amount
+        if (collected >= amount) {
+            break
+        }
+    }
+    if (collected < amount) {
+        throw InsufficientBalanceException(amount - collected)
+    }
+    return inputs.toList()
+}

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/util/querier.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/util/querier.kt
@@ -1,4 +1,4 @@
-package jp.datachain.corda.ibc.flows
+package jp.datachain.corda.ibc.flows.util
 
 import jp.datachain.corda.ibc.ics20.Bank
 import jp.datachain.corda.ibc.ics24.Genesis

--- a/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/util/querier.kt
+++ b/workflows/src/main/kotlin/jp/datachain/corda/ibc/flows/util/querier.kt
@@ -1,6 +1,7 @@
 package jp.datachain.corda.ibc.flows.util
 
 import jp.datachain.corda.ibc.ics20.Bank
+import jp.datachain.corda.ibc.ics20cash.CashBank
 import jp.datachain.corda.ibc.ics24.Genesis
 import jp.datachain.corda.ibc.ics24.Host
 import jp.datachain.corda.ibc.ics24.Identifier
@@ -20,6 +21,10 @@ fun VaultService.queryIbcHost(baseId: StateRef) : StateAndRef<Host>? = queryBy<H
 ).states.singleOrNull()
 
 fun VaultService.queryIbcBank(baseId: StateRef) : StateAndRef<Bank>? = queryBy<Bank>(
+        QueryCriteria.LinearStateQueryCriteria(externalId = listOf(baseId.toString()))
+).states.singleOrNull()
+
+fun VaultService.queryIbcCashBank(baseId: StateRef) : StateAndRef<CashBank>? = queryBy<CashBank>(
         QueryCriteria.LinearStateQueryCriteria(externalId = listOf(baseId.toString()))
 ).states.singleOrNull()
 


### PR DESCRIPTION
This is incomplete/experimental implementation yet.
Especially at the moment, Cash states are locked to a _TRUSTED_ user (called "Bank"), while they are supposed to be locked to a smart contract in the ICS-20 spec.
In the future work, this gap will be filled using the encumbrance feature of Corda.

Signed-off-by: Masanori Yoshida <masanori.yoshida@datachain.jp>